### PR TITLE
Make puppetdb startup timeout configurable

### DIFF
--- a/lib/puppet/type/puppetdb_conn_validator.rb
+++ b/lib/puppet/type/puppetdb_conn_validator.rb
@@ -23,4 +23,18 @@ Puppet::Type.newtype(:puppetdb_conn_validator) do
     desc 'The port that the puppetdb server should be listening on.'
   end
 
+  newparam(:timeout) do
+    desc 'The max number of seconds that the validator should wait before giving up and deciding that puppetdb is not running; defaults to 15 seconds.'
+    defaultto 15
+
+    validate do |value|
+      # This will raise an error if the string is not convertible to an integer
+      Integer(value)
+    end
+
+    munge do |value|
+      Integer(value)
+    end
+  end
+
 end

--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -23,6 +23,10 @@
 #                         be installed.  You may specify an explicit version
 #                         number, 'present', or 'latest'.  Defaults to
 #                         'present'.
+#   ['puppetdb_startup_timeout']  - The maximum amount of time that the module
+#                         should wait for puppetdb to start up; this is most
+#                         important during the initial install of puppetdb.
+#                         Defaults to 15 seconds.
 #   ['restart_puppet']  - If true, the module will restart the puppet master when
 #                         necessary.  The default is 'true'.  If set to 'false',
 #                         you must restart the service manually in order to pick
@@ -43,15 +47,16 @@
 # TODO: finish porting this to use params
 #
 class puppetdb::master::config(
-  $puppetdb_server      = $::clientcert,
-  $puppetdb_port        = 8081,
-  $manage_routes        = true,
-  $manage_storeconfigs  = true,
-  $puppet_confdir       = $puppetdb::params::puppet_confdir,
-  $puppet_conf          = $puppetdb::params::puppet_conf,
-  $puppetdb_version     = $puppetdb::params::puppetdb_version,
-  $terminus_package     = $puppetdb::params::terminus_package,
-  $puppet_service_name  = $puppetdb::params::puppet_service_name,
+  $puppetdb_server          = $::clientcert,
+  $puppetdb_port            = 8081,
+  $manage_routes            = true,
+  $manage_storeconfigs      = true,
+  $puppet_confdir           = $puppetdb::params::puppet_confdir,
+  $puppet_conf              = $puppetdb::params::puppet_conf,
+  $puppetdb_version         = $puppetdb::params::puppetdb_version,
+  $terminus_package         = $puppetdb::params::terminus_package,
+  $puppet_service_name      = $puppetdb::params::puppet_service_name,
+  $puppetdb_startup_timeout = $puppetdb::params::puppetdb_startup_timeout,
   $restart_puppet       = true,
 ) inherits puppetdb::params {
 
@@ -64,6 +69,7 @@ class puppetdb::master::config(
   puppetdb_conn_validator { 'puppetdb_conn':
     puppetdb_server => $puppetdb_server,
     puppetdb_port   => $puppetdb_port,
+    timeout         => $puppetdb_startup_timeout,
     require         => Package[$terminus_package],
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -62,5 +62,6 @@ class puppetdb::params {
     $terminus_package     = 'puppetdb-terminus'
   }
 
-  $puppet_conf          = "${puppet_confdir}/puppet.conf"
+  $puppet_conf              = "${puppet_confdir}/puppet.conf"
+  $puppetdb_startup_timeout = 15
 }


### PR DESCRIPTION
In some environments, puppetdb can take longer than 10 seconds
to start up.  Prior to this commit, that value was hard coded
and the module would sometimes fail when it wouldn't have failed
with a slightly larger timeout.  This commit makes the timeout
configurable, and also increases the default value to 15 seconds.
