### PR TITLE
Fix embedded db setup in Puppet Enterprise

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,6 +53,7 @@ class puppetdb::params {
     $puppet_service_name  = 'pe-httpd'
     $puppet_confdir       = '/etc/puppetlabs/puppet'
     $terminus_package     = 'pe-puppetdb-terminus'
+    $embedded_subname     = 'file:/opt/puppet/share/puppetdb/db/db;hsqldb.tx=mvcc;sql.syntax_pgs=true'
   } else {
     $puppetdb_package     = 'puppetdb'
     $puppetdb_service     = 'puppetdb'
@@ -60,6 +61,7 @@ class puppetdb::params {
     $puppet_service_name  = 'puppetmaster'
     $puppet_confdir       = '/etc/puppet'
     $terminus_package     = 'puppetdb-terminus'
+    $embedded_subname     = 'file:/usr/share/puppetdb/db/db;hsqldb.tx=mvcc;sql.syntax_pgs=true'
   }
 
   $puppet_conf              = "${puppet_confdir}/puppet.conf"

--- a/manifests/server/database_ini.pp
+++ b/manifests/server/database_ini.pp
@@ -70,7 +70,7 @@ class puppetdb::server::database_ini(
 
     $classname   = 'org.hsqldb.jdbcDriver'
     $subprotocol = 'hsqldb'
-    $subname     = 'file:/usr/share/puppetdb/db/db;hsqldb.tx=mvcc;sql.syntax_pgs=true'
+    $subname     = $puppetdb::params::embedded_subname
 
   } elsif $database == 'postgres' {
     $classname = 'org.postgresql.Driver'


### PR DESCRIPTION
The subname value in database.ini when using an embedded database varies between the Puppet Enterprise package and the FOSS Puppet package. Previously, the PuppetDB module could not successfully manage an embedded database on a PE master. This commit adds an additional parameter and utilization to account for this.
