### PR TITLE
17594 - PuppetDB - Add ability to set standard host listen address and open firewall to standard port

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,15 +15,56 @@
 # puppetdb.  You can use the `puppetdb::master::config` class to accomplish this.
 #
 # Parameters:
-#   ['database'] - Which database backend to use; legal values are
-#                  `postgres` (default) or `embedded`.  (The `embedded`
-#                  db can be used for very small installations or for
-#                  testing, but is not recommended for use in production
-#                  environments.  For more info, see the puppetdb docs.)
+#   ['listen_address']     - The address that the web server should bind to
+#                            for HTTP requests.  (defaults to `localhost`.
+#                            '0.0.0.0' = all)
+#   ['listen_port']        - The port on which the puppetdb web server should
+#                            accept HTTP requests (defaults to 8080).
+#   ['open_listen_port']   - If true, open the http listen port on the firewall. 
+#                            (defaults to false).
+#   ['ssl_listen_address'] - The address that the web server should bind to
+#                            for HTTPS requests.  (defaults to `$::clientcert`.)
+#                            Set to '0.0.0.0' to listen on all addresses.
+#   ['ssl_listen_port']    - The port on which the puppetdb web server should
+#                            accept HTTPS requests (defaults to 8081).
+#   ['open_ssl_listen_port'] - If true, open the ssl listen port on the firewall. 
+#                            (defaults to false).
+#   ['database']           - Which database backend to use; legal values are
+#                            `postgres` (default) or `embedded`.  (The `embedded`
+#                            db can be used for very small installations or for
+#                            testing, but is not recommended for use in production
+#                            environments.  For more info, see the puppetdb docs.)
+#   ['database_host']      - The hostname or IP address of the database server.
+#                            (defaults to `localhost`; ignored for `embedded` db)
+#   ['database_port']      - The port that the database server listens on.
+#                            (defaults to `5432`; ignored for `embedded` db)
+#   ['database_username']  - The name of the database user to connect as.
+#                            (defaults to `puppetdb`; ignored for `embedded` db)
+#   ['database_password']  - The password for the database user.
+#                            (defaults to `puppetdb`; ignored for `embedded` db)
+#   ['database_name']      - The name of the database instance to connect to.
+#                            (defaults to `puppetdb`; ignored for `embedded` db)
+#   ['database_package']   - The puppetdb package name in the package manager
 #   ['puppetdb_version']   - The version of the `puppetdb` package that should
-#                  be installed.  You may specify an explicit version
-#                  number, 'present', or 'latest'.  Defaults to
-#                  'present'.
+#                            be installed.  You may specify an explicit version
+#                            number, 'present', or 'latest'.  (defaults to
+#                            'present')
+#   ['puppetdb_service']   - The name of the puppetdb service.
+#   ['postgres_listen_addresses'] - The addresses for postgres to listen on.
+#                            (defaults to 'localhost'. '*' = all)
+#   ['open_postgres_port'] - If true, open the postgres listen port on the firewall. 
+#                            (defaults to false).
+#   ['manage_redhat_firewall'] - DEPRECATED: Use open_ssl_listen_port instead.
+#                            boolean indicating whether or not the module
+#                            should open a port in the firewall on redhat-based
+#                            systems.  Defaults to `false`.  This parameter is
+#                            likely to change in future versions.  Possible
+#                            changes include support for non-RedHat systems and
+#                            finer-grained control over the firewall rule
+#                            (currently, it simply opens up the postgres port to
+#                            all TCP connections).
+#   ['confdir']            - The puppetdb configuration directory; defaults to
+#                            `/etc/puppetdb/conf.d`.
 #
 # Actions:
 # - Creates and manages a puppetdb server and its database server/instance.
@@ -34,30 +75,59 @@
 # Sample Usage:
 #   include puppetdb
 #
-#
-# TODO: expose more parameters
-#
 class puppetdb(
-  $database               = $puppetdb::params::database,
-  $puppetdb_package       = $puppetdb::params::puppetdb_package,
-  $puppetdb_version       = $puppetdb::params::puppetdb_version,
-  $puppetdb_service       = $puppetdb::params::puppetdb_service,
-  $confdir                = $puppetdb::params::confdir,
-  $manage_redhat_firewall = $puppetdb::params::manage_redhat_firewall,
+  $listen_address            = $puppetdb::params::listen_address,
+  $listen_port               = $puppetdb::params::listen_port,
+  $open_listen_port          = $puppetdb::params::open_listen_port,
+  $ssl_listen_address        = $puppetdb::params::ssl_listen_address,
+  $ssl_listen_port           = $puppetdb::params::ssl_listen_port,
+  $open_ssl_listen_port      = $puppetdb::params::open_ssl_listen_port,
+  $database                  = $puppetdb::params::database,
+  $database_host             = $puppetdb::params::database_host,
+  $database_port             = $puppetdb::params::database_port,
+  $database_username         = $puppetdb::params::database_username,
+  $database_password         = $puppetdb::params::database_password,
+  $database_name             = $puppetdb::params::database_name,
+  $puppetdb_package          = $puppetdb::params::puppetdb_package,
+  $puppetdb_version          = $puppetdb::params::puppetdb_version,
+  $puppetdb_service          = $puppetdb::params::puppetdb_service,
+  $postgres_listen_addresses = $puppetdb::params::postgres_listen_addresses,
+  $open_postgres_port        = $puppetdb::params::open_postgres_port,
+  $manage_redhat_firewall    = $puppetdb::params::manage_redhat_firewall,
+  $confdir                   = $puppetdb::params::confdir
 ) inherits puppetdb::params {
 
+  if ($manage_redhat_firewall) {
+    notify {'Deprecation notice: `$manage_redhat_firewall` has been deprecated in `puppetdb` class and will be removed in a future versions. Use $open_ssl_listen_port and $open_postgres_port instead.':}
+  }
+
   class { 'puppetdb::server':
-    database               => $database,
-    puppetdb_package       => $puppetdb_package,
-    puppetdb_version       => $puppetdb_version,
-    puppetdb_service       => $puppetdb_service,
-    confdir                => $confdir,
-    manage_redhat_firewall => $manage_redhat_firewall,
+    listen_address          => $listen_address,
+    listen_port             => $listen_port,
+    open_listen_port        => $open_listen_port,
+    ssl_listen_address      => $ssl_listen_address,
+    ssl_listen_port         => $ssl_listen_port,
+    open_ssl_listen_port    => $open_ssl_listen_port,
+    database                => $database,
+    database_host           => $database_host,
+    database_port           => $database_port,
+    database_username       => $database_username,
+    database_password       => $database_password,
+    database_name           => $database_name,
+    puppetdb_package        => $puppetdb_package,
+    puppetdb_version        => $puppetdb_version,
+    puppetdb_service        => $puppetdb_service,
+    manage_redhat_firewall  => $manage_redhat_firewall,
+    confdir                 => $confdir
   }
 
   if ($database == 'postgres') {
     class { 'puppetdb::database::postgresql':
-      manage_redhat_firewall => $manage_redhat_firewall,
+      manage_redhat_firewall => $manage_redhat_firewall ? {
+        true                 => $manage_redhat_firewall,
+        false                => $open_postgres_port,
+      },
+      listen_addresses       => $postgres_listen_addresses,
       before                 => Class['puppetdb::server']
     }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,10 +11,16 @@
 # Sample Usage:
 #
 class puppetdb::params {
-  $ssl_listen_address    = $::clientcert
-  $ssl_listen_port       = '8081'
+  $listen_address            = 'localhost'
+  $listen_port               = '8080'
+  $open_listen_port          = false
+  $ssl_listen_address        = $::clientcert
+  $ssl_listen_port           = '8081'
+  $open_ssl_listen_port      = false
+  $postgres_listen_addresses = 'localhost'
+  $open_postgres_port        = false
 
-  $database          = 'postgres'
+  $database                  = 'postgres'
 
   # The remaining database settings are not used for an embedded database
   $database_host          = 'localhost'
@@ -26,7 +32,7 @@ class puppetdb::params {
   $puppetdb_version       = 'present'
 
   # TODO: figure out a way to make this not platform-specific
-  $manage_redhat_firewall = true
+  $manage_redhat_firewall = false
 
   $gc_interval            = '60'
 

--- a/manifests/server/firewall.pp
+++ b/manifests/server/firewall.pp
@@ -1,11 +1,23 @@
 class puppetdb::server::firewall(
-    $port                   = $puppetdb::params::ssl_listen_port,
+    $port                   = '',
+    $http_port              = $puppetdb::params::listen_port,             
+    $open_http_port         = $puppetdb::params::open_listen_port,
+    $ssl_port               = $puppetdb::params::ssl_listen_port,
+    $open_ssl_port          = $puppetdb::params::open_ssl_listen_port,
     $manage_redhat_firewall = $puppetdb::params::manage_redhat_firewall,
 ) inherits puppetdb::params {
   # TODO: figure out a way to make this not platform-specific; debian and ubuntu
   # have an out-of-the-box firewall configuration that seems trickier to manage.
   # TODO: the firewall module should be able to handle this itself
-  if ($manage_redhat_firewall and $puppetdb::params::firewall_supported) {
+  if ($puppetdb::params::firewall_supported) {
+
+    if ($manage_redhat_firewall) {
+      notify {'Deprecation notice: `$manage_redhat_firewall` is deprecated in the `puppetdb::service::firewall` class and will be removed in a future version. Use `open_http_port` and `open_ssl_port` instead.':}
+
+      if ($open_ssl_port) {
+        fail('`$manage_redhat_firewall` and `$open_ssl_port` cannot both be specified.')
+      }
+    }
 
     exec { 'puppetdb-persist-firewall':
       command     => $puppetdb::params::persist_firewall_command,
@@ -15,11 +27,29 @@ class puppetdb::server::firewall(
     Firewall {
       notify => Exec['puppetdb-persist-firewall']
     }
+    
+    if ($port) {
+      notify { 'Deprecation notice: `port` parameter will be removed in future versions of the puppetdb module. Please use ssl_port instead.': }
+    }
 
-    firewall { "${port} accept - puppetdb":
-      port   => $port,
-      proto  => 'tcp',
-      action => 'accept',
+    if ($port and $ssl_port) {
+      fail('`port` and `ssl_port` cannot both be defined. `port` is deprecated in favor of `ssl_port`')
+    }
+    
+    if ($open_http_port) {
+      firewall { "${http_port} accept - puppetdb":
+        port   => $http_port,
+        proto  => 'tcp',
+        action => 'accept',
+      }
+    } 
+
+    if ($open_ssl_port or $manage_redhat_firewall) {
+      firewall { "${ssl_port} accept - puppetdb":
+        port   => $ssl_port,
+        proto  => 'tcp',
+        action => 'accept',
+      }
     }
   }
 }

--- a/manifests/server/jetty_ini.pp
+++ b/manifests/server/jetty_ini.pp
@@ -4,6 +4,10 @@
 # for puppetdb's embedded web server.
 #
 # Parameters:
+#   ['listen_address']     - The address that the web server should bind to
+#                            for HTTP requests.  (defaults to `localhost`.)
+#   ['listen_port']        - The port on which the puppetdb web server should
+#                            accept HTTP requests (defaults to 8080).
 #   ['ssl_listen_address'] - The address that the web server should bind to
 #                            for HTTPS requests.  (defaults to `$::clientcert`.)
 #   ['ssl_listen_port']    - The port on which the puppetdb web server should
@@ -25,9 +29,9 @@
 #       ssl_listen_port         => 8081,
 #   }
 #
-#TODO add support for non-ssl config
-#
 class puppetdb::server::jetty_ini(
+  $listen_address     = $puppetdb::params::listen_address,
+  $listen_port        = $puppetdb::params::listen_port,  
   $ssl_listen_address = $puppetdb::params::ssl_listen_address,
   $ssl_listen_port    = $puppetdb::params::ssl_listen_port,
   $confdir            = $puppetdb::params::confdir,
@@ -42,6 +46,16 @@ class puppetdb::server::jetty_ini(
 
   # TODO: figure out some way to make sure that the ini_file module is installed,
   #  because otherwise these will silently fail to do anything.
+
+  ini_setting {'puppetdb_host':
+    setting => 'host',
+    value   => $listen_address,
+  }
+
+  ini_setting {'puppetdb_port':
+    setting => 'port',
+    value   => $listen_port,
+  }
 
   ini_setting {'puppetdb_sslhost':
     setting => 'ssl-host',


### PR DESCRIPTION
I tested various combinations of the old manage_redhat_firewall param and the new open port params.  The deprecation notices and fail messages work great.

I also adjusted the distributed example file to show how to open ports for postgres and puppetdb when necessary.

See notes on pull request code for more information.
