### PR TITLE
Refactor validate_db to use postgresql validation class

### DIFF
--- a/manifests/server/validate_db.pp
+++ b/manifests/server/validate_db.pp
@@ -53,7 +53,7 @@ class puppetdb::server::validate_db(
 
   # We don't need any validation for the embedded database, presumably.
   if ($database == 'postgres') {
-    ::postgresql::validate_db_connection { 'validate puppetdb postgres connection':
+    class { '::postgresql::validate_db_connection':
       database_host     => $database_host,
       database_port     => $database_port,
       database_username => $database_username,


### PR DESCRIPTION
Pull request #52 to the postgres module refactors
the validate_db define to be a class.

This corresponding PR updates the puppetdb::server::validate_db
invocation to declare a class and not a define.
