### PR TITLE
ON HOLD: Use a versioned API, like the service says

### DIFF
--- a/lib/puppet/provider/puppetdb_conn_validator/puppet_https.rb
+++ b/lib/puppet/provider/puppetdb_conn_validator/puppet_https.rb
@@ -16,7 +16,7 @@ def attempt_connection
     # All that we care about is that we are able to connect successfully via
     # https, so here we're simpling hitting a somewhat arbitrary low-impact URL
     # on the puppetdb server.
-    path = "/metrics/mbean/java.lang:type=Memory"
+    path = "/v1/metrics/mbean/java.lang:type=Memory"
     headers = {"Accept" => "application/json"}
     conn = Puppet::Network::HttpPool.http_instance(host, port, true)
     response = conn.get(path, headers)


### PR DESCRIPTION
From the puppetdb log while this resource attempts to connect:
2013-02-17 04:23:08,258 WARN  [qtp1549648037-37] [http.server] Use of unversioned APIs is deprecated; please use /v1/metrics/mbean/java.lang:type=Memory
