### PR TITLE
Support for remote puppetdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,13 @@ If true, the module will overwrite the puppet master's routes file to configure 
 
 If true, the module will manage the puppet master's storeconfig settings (defaults to true).
 
+####`manage_config`
+If true, the module will store values from puppetdb_server and puppetdb_port parameters in the puppetdb configuration file.
+If false, an existing puppetdb configuration file will be used to retrieve server and port values.
+
+####`strict_validation`
+If true, the module will fail if puppetdb is not reachable, otherwise it will preconfigure puppetdb without checking.
+
 ####`puppet_confdir`
 
 Puppet's config directory (defaults to `/etc/puppet`).

--- a/lib/puppet/provider/puppetdb_conn_validator/puppet_https.rb
+++ b/lib/puppet/provider/puppetdb_conn_validator/puppet_https.rb
@@ -1,35 +1,16 @@
-require 'puppet/network/http_pool'
+# See: #10295 for more details.
+#
+# This is a workaround for bug: #4248 whereby ruby files outside of the normal
+# provider/type path do not load until pluginsync has occured on the puppetmaster
+#
+# In this case I'm trying the relative path first, then falling back to normal
+# mechanisms. This should be fixed in future versions of puppet but it looks
+# like we'll need to maintain this for some time perhaps.
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","..",".."))
+require 'puppet/util/puppetdb_validator'
 
 # This file contains a provider for the resource type `puppetdb_conn_validator`,
 # which validates the puppetdb connection by attempting an https connection.
-
-# Utility method; attempts to make an https connection to the puppetdb server.
-# This is abstracted out into a method so that it can be called multiple times
-# for retry attempts.
-#
-# @return true if the connection is successful, false otherwise.
-def attempt_connection
-  begin
-    host = resource[:puppetdb_server]
-    port = resource[:puppetdb_port]
-
-    # All that we care about is that we are able to connect successfully via
-    # https, so here we're simpling hitting a somewhat arbitrary low-impact URL
-    # on the puppetdb server.
-    path = "/metrics/mbean/java.lang:type=Memory"
-    headers = {"Accept" => "application/json"}
-    conn = Puppet::Network::HttpPool.http_instance(host, port, true)
-    response = conn.get(path, headers)
-    unless response.kind_of?(Net::HTTPSuccess)
-      Puppet.err "Unable to connect to puppetdb server (#{host}:#{port}): [#{response.code}] #{response.msg}"
-      return false
-    end
-    return true
-  rescue Errno::ECONNREFUSED => e
-    Puppet.notice "Unable to connect to puppetdb server (#{host}:#{port}): #{e.inspect} "
-    return false
-  end
-end
 
 Puppet::Type.type(:puppetdb_conn_validator).provide(:puppet_https) do
   desc "A provider for the resource type `puppetdb_conn_validator`,
@@ -41,7 +22,7 @@ Puppet::Type.type(:puppetdb_conn_validator).provide(:puppet_https) do
     start_time = Time.now
     timeout = resource[:timeout]
 
-    success = attempt_connection
+    success = validator.attempt_connection
     unless success
       while (Time.now - start_time) < timeout
         # It can take several seconds for the puppetdb server to start up;
@@ -50,7 +31,7 @@ Puppet::Type.type(:puppetdb_conn_validator).provide(:puppet_https) do
         # seconds until the configurable timeout has expired.
         Puppet.notice("Failed to connect to puppetdb; sleeping 2 seconds before retry")
         sleep 2
-        success = attempt_connection
+        success = validator.attempt_connection
       end
     end
 
@@ -65,8 +46,13 @@ Puppet::Type.type(:puppetdb_conn_validator).provide(:puppet_https) do
     # If `#create` is called, that means that `#exists?` returned false, which
     # means that the connection could not be established... so we need to
     # cause a failure here.
-    raise Puppet::Error, "Unable to connect to puppetdb server! (#{resource[:puppetdb_server]}:#{resource[:puppetdb_port]})"
+    raise Puppet::Error, "Unable to connect to puppetdb server! (#{@validator.puppetdb_server}:#{@validator.puppetdb_port})"
   end
 
+  # @api private
+  def validator
+    @validator ||= Puppet::Util::PuppetdbValidator.new(resource[:puppetdb_server], resource[:puppetdb_port])
+  end
 
 end
+

--- a/lib/puppet/util/puppetdb_validator.rb
+++ b/lib/puppet/util/puppetdb_validator.rb
@@ -1,0 +1,39 @@
+require 'puppet/network/http_pool'
+
+module Puppet
+  module Util
+    class PuppetdbValidator
+      attr_reader :puppetdb_server
+      attr_reader :puppetdb_port
+
+      def initialize(puppetdb_server, puppetdb_port)
+        @puppetdb_server = puppetdb_server
+        @puppetdb_port = puppetdb_port
+      end
+
+      # Utility method; attempts to make an https connection to the puppetdb server.
+      # This is abstracted out into a method so that it can be called multiple times
+      # for retry attempts.
+      #
+      # @return true if the connection is successful, false otherwise.
+      def attempt_connection
+        # All that we care about is that we are able to connect successfully via
+        # https, so here we're simpling hitting a somewhat arbitrary low-impact URL
+        # on the puppetdb server.
+        path = "/metrics/mbean/java.lang:type=Memory"
+        headers = {"Accept" => "application/json"}
+        conn = Puppet::Network::HttpPool.http_instance(@puppetdb_server, @puppetdb_port, true)
+        response = conn.get(path, headers)
+        unless response.kind_of?(Net::HTTPSuccess)
+          Puppet.notice "Unable to connect to puppetdb server (#{@puppetdb_server}:#{@puppetdb_port}): [#{response.code}] #{response.msg}"
+          return false
+        end
+        return true
+      rescue Exception => e
+        Puppet.notice "Unable to connect to puppetdb server (#{@puppetdb_server}:#{@puppetdb_port}): #{e.message}"
+        return false
+      end
+    end
+  end
+end
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -140,7 +140,7 @@ class puppetdb(
   validate_re ($report_ttl_real, ['^(\d)+[s,m,d]$'], "report_ttl is <${report_ttl}> which does not match the regex validation")
 
   if ($manage_redhat_firewall != undef) {
-    notify {'Deprecation notice: `$manage_redhat_firewall` has been deprecated in `puppetdb` class and will be removed in a future versions. Use $open_ssl_listen_port and $open_postgres_port instead.':}
+    notify {'Deprecation notice: `$manage_redhat_firewall` has been deprecated in `puppetdb` class and will be removed in a future version. Use $open_ssl_listen_port and $open_postgres_port instead.':}
   }
 
   class { 'puppetdb::server':

--- a/spec/unit/util/puppetdb_validator_spec.rb
+++ b/spec/unit/util/puppetdb_validator_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+require 'puppet/util/puppetdb_validator'
+
+describe 'Puppet::Util::PuppetdbValidator' do
+
+  before do
+    response_ok = stub()
+    response_ok.stubs(:kind_of?).with(Net::HTTPSuccess).returns(true)
+    response_not_found = stub()
+    response_not_found.stubs(:kind_of?).with(Net::HTTPSuccess).returns(false)
+    response_not_found.stubs(:code).returns(404)
+    response_not_found.stubs(:msg).returns('Not found')
+
+    conn_ok = stub()
+    conn_ok.stubs(:get).with('/metrics/mbean/java.lang:type=Memory', {"Accept" => "application/json"}).returns(response_ok)
+
+    conn_not_found = stub()
+    conn_not_found.stubs(:get).with('/metrics/mbean/java.lang:type=Memory', {"Accept" => "application/json"}).returns(response_not_found)
+
+    Puppet::Network::HttpPool.stubs(:http_instance).raises('Unknown host')
+    Puppet::Network::HttpPool.stubs(:http_instance).with('mypuppetdb.com', 8080, true).raises('Connection refused')
+    Puppet::Network::HttpPool.stubs(:http_instance).with('mypuppetdb.com', 8081, true).returns(conn_ok)
+    Puppet::Network::HttpPool.stubs(:http_instance).with('wrongserver.com', 8081, true).returns(conn_not_found)
+  end
+
+  it 'returns true if connection succeeds' do
+    validator = Puppet::Util::PuppetdbValidator.new('mypuppetdb.com', 8081)
+    validator.attempt_connection.should be_true
+  end
+
+  it 'returns false and issues an appropriate notice if connection is refused' do
+    puppetdb_server = 'mypuppetdb.com'
+    puppetdb_port = 8080
+    validator = Puppet::Util::PuppetdbValidator.new(puppetdb_server, puppetdb_port)
+    Puppet.expects(:notice).with("Unable to connect to puppetdb server (#{puppetdb_server}:#{puppetdb_port}): Connection refused")
+    #Puppet.expects(:notice).with("Unable to connect to puppetdb server (#{puppetdb_server}:#{puppetdb_port}): [404] Not found")
+    validator.attempt_connection.should be_false    
+  end
+
+  it 'returns false and issues an appropriate notice if connection succeeds but puppetdb is not available' do
+    puppetdb_server = 'wrongserver.com'
+    puppetdb_port = 8081
+    validator = Puppet::Util::PuppetdbValidator.new(puppetdb_server, puppetdb_port)
+    Puppet.expects(:notice).with("Unable to connect to puppetdb server (#{puppetdb_server}:#{puppetdb_port}): [404] Not found")
+    validator.attempt_connection.should be_false    
+  end
+
+
+  it 'returns false and issues an appropriate notice if host:port is unreachable or does not exist' do
+    puppetdb_server = 'non-existing.com'
+    puppetdb_port = nil
+    validator = Puppet::Util::PuppetdbValidator.new(puppetdb_server, puppetdb_port)
+    Puppet.expects(:notice).with("Unable to connect to puppetdb server (#{puppetdb_server}:#{puppetdb_port}): Unknown host")
+    validator.attempt_connection.should be_false    
+  end
+end


### PR DESCRIPTION
This PR contains changes that were required to handle connection validation in a more flexible way. The new solution also allows (on demand, not by default) to store configuration settings even when puppetdb is not reachable.
