### PR TITLE
Add unit suffix to TTL settings to avoid issue #20099

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,8 +42,8 @@ class puppetdb::params {
   $database_password      = 'puppetdb'
 
   # These settings manage the various auto-deactivation and auto-purge settings
-  $node_ttl               = '0'
-  $node_purge_ttl         = '0'
+  $node_ttl               = '0s'
+  $node_purge_ttl         = '0s'
   $report_ttl             = '7d'
 
   $puppetdb_version       = 'present'


### PR DESCRIPTION
The defaults in the module are missing units, so they hit [#20099](https://projects.puppetlabs.com/issues/20099) with assertion errors.  Nasty.
