### PR TITLE
report_ttl, node_ttl and node_purge_ttl not working

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -111,22 +111,25 @@ class puppetdb(
   }
 
   class { 'puppetdb::server':
-    listen_address          => $listen_address,
-    listen_port             => $listen_port,
-    open_listen_port        => $open_listen_port,
-    ssl_listen_address      => $ssl_listen_address,
-    ssl_listen_port         => $ssl_listen_port,
-    open_ssl_listen_port    => $open_ssl_listen_port,
-    database                => $database,
-    database_port           => $database_port,
-    database_username       => $database_username,
-    database_password       => $database_password,
-    database_name           => $database_name,
-    puppetdb_package        => $puppetdb_package,
-    puppetdb_version        => $puppetdb_version,
-    puppetdb_service        => $puppetdb_service,
-    manage_redhat_firewall  => $manage_redhat_firewall,
-    confdir                 => $confdir
+    listen_address         => $listen_address,
+    listen_port            => $listen_port,
+    open_listen_port       => $open_listen_port,
+    ssl_listen_address     => $ssl_listen_address,
+    ssl_listen_port        => $ssl_listen_port,
+    open_ssl_listen_port   => $open_ssl_listen_port,
+    database               => $database,
+    database_port          => $database_port,
+    database_username      => $database_username,
+    database_password      => $database_password,
+    database_name          => $database_name,
+    node_ttl               => $node_ttl,
+    node_purge_ttl         => $node_purge_ttl,
+    report_ttl             => $report_ttl,
+    puppetdb_package       => $puppetdb_package,
+    puppetdb_version       => $puppetdb_version,
+    puppetdb_service       => $puppetdb_service,
+    manage_redhat_firewall => $manage_redhat_firewall,
+    confdir                => $confdir
   }
 
   if ($database == 'postgres') {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -135,6 +135,9 @@ class puppetdb::server(
     database_username => $database_username,
     database_password => $database_password,
     database_name     => $database_name,
+    node_ttl          => $node_ttl,
+    node_purge_ttl    => $node_purge_ttl,
+    report_ttl        => $report_ttl,
     confdir           => $confdir,
     notify            => Service[$puppetdb_service],
   }

--- a/manifests/server/database_ini.pp
+++ b/manifests/server/database_ini.pp
@@ -43,6 +43,9 @@ class puppetdb::server::database_ini(
   $database_username = $puppetdb::params::database_username,
   $database_password = $puppetdb::params::database_password,
   $database_name     = $puppetdb::params::database_name,
+  $node_ttl          = $puppetdb::params::node_ttl,
+  $node_purge_ttl    = $puppetdb::params::node_purge_ttl,
+  $report_ttl        = $puppetdb::params::report_ttl,
   $confdir           = $puppetdb::params::confdir,
 ) inherits puppetdb::params {
 
@@ -116,16 +119,16 @@ class puppetdb::server::database_ini(
 
   ini_setting {'puppetdb_node_ttl':
     setting => 'node-ttl',
-    value   => $puppetdb::params::node_ttl,
+    value   => $node_ttl,
   }
 
   ini_setting {'puppetdb_node_purge_ttl':
     setting => 'node-purge-ttl',
-    value   => $puppetdb::params::node_purge_ttl,
+    value   => $node_purge_ttl,
   }
 
   ini_setting {'puppetdb_report_ttl':
     setting => 'report-ttl',
-    value   => $puppetdb::params::report_ttl,
+    value   => $report_ttl,
   }
 }


### PR DESCRIPTION
The parameters are set in the class puppetdb or puppetdb::server however it is not being sent to the puppetdb::server::database_ini.

And in puppetdb::server::database_ini it uses the default value from params.pp instead of any value being received by the class.

This pull request fixes the 3 new parameters to work.
