### PR TITLE
Add tests for puppetdb::server::jetty_ini

### DIFF
--- a/spec/unit/classes/server/jetty_ini_spec.rb
+++ b/spec/unit/classes/server/jetty_ini_spec.rb
@@ -18,7 +18,7 @@ describe 'puppetdb::server::jetty_ini', :type => :class do
              'path'    => '/etc/puppetdb/conf.d/jetty.ini',
              'section' => 'jetty',
              'setting' => 'host',
-             'value'   => 'localhost',
+             'value'   => 'localhost'
              )}
       it { should contain_ini_setting('puppetdb_port').
         with(
@@ -26,7 +26,7 @@ describe 'puppetdb::server::jetty_ini', :type => :class do
              'path'    => '/etc/puppetdb/conf.d/jetty.ini',
              'section' => 'jetty',
              'setting' => 'port',
-             'value'   => 8080,
+             'value'   => 8080
              )}
       it { should contain_ini_setting('puppetdb_sslhost').
         with(
@@ -34,7 +34,7 @@ describe 'puppetdb::server::jetty_ini', :type => :class do
              'path'    => '/etc/puppetdb/conf.d/jetty.ini',
              'section' => 'jetty',
              'setting' => 'ssl-host',
-             'value'   => 'test.domain.local',
+             'value'   => 'test.domain.local'
              )}
       it { should contain_ini_setting('puppetdb_sslport').
         with(
@@ -42,7 +42,7 @@ describe 'puppetdb::server::jetty_ini', :type => :class do
              'path'    => '/etc/puppetdb/conf.d/jetty.ini',
              'section' => 'jetty',
              'setting' => 'ssl-port',
-             'value'   => 8081,
+             'value'   => 8081
              )}
     end
   end


### PR DESCRIPTION
This patch adds unit tests for the jetty_ini class.

I added these in a separate pull request to serve as regression tests for my pull request #52, in which I propose to add an additional option to the jetty_ini class.
