### PR TITLE
Separate DB instance and DB user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,9 @@ The `puppetdb::database::postgresql` class manages a postgresql server for use b
 
 The `listen_address` is a comma-separated list of hostnames or IP addresses on which the postgres server should listen for incoming connections. This defaults to `localhost`. This parameter maps directly to postgresql's `listen_addresses` config option; use a '*' to allow connections on any accessible address.
 
+### puppetdb::database::postgresql_db
+The `puppetdb::database::postgresql_db` class sets up the puppetdb database and database user accounts. This is included from the `puppetdb::database::postgresql` class but can be used on its own if you want to use your own classes to configure the postgresql server itself in a way that the `puppetdb::database::postgresql` doesn't support.
+
 Implementation
 ---------------
 

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -70,10 +70,9 @@ class puppetdb::database::postgresql(
   }
 
   # create the puppetdb database
-  postgresql::db{ $database_name:
-    user     => $database_username,
-    password => $database_password,
-    grant    => 'all',
-    require  => Class['::postgresql::server'],
+  class { 'puppetdb::database::postgresql_db':
+    database_name     => $database_name,
+    database_username => $database_username,
+    database_password => $database_password,
   }
 }

--- a/manifests/database/postgresql_db.pp
+++ b/manifests/database/postgresql_db.pp
@@ -1,0 +1,41 @@
+# Class: puppetdb::database::postgresql_db
+#
+# This class manages a postgresql database instance suitable for use
+# with puppetdb.  It uses the `inkling/postgresql` puppet module for
+# for creating the puppetdb database instance and user account.
+#
+# This class is included from the puppetdb::database::postgresql class
+# but for maximum configurability, you may choose to use this class directly
+# and set up the database server itself using `puppetlabs/postgresql` yourself.
+#
+# Parameters:
+#   ['database_name']      - The name of the database instance to connect to.
+#                            (defaults to `puppetdb`)
+#   ['database_username']  - The name of the database user to connect as.
+#                            (defaults to `puppetdb`)
+#   ['database_password']  - The password for the database user.
+#                            (defaults to `puppetdb`)
+# Actions:
+# - Creates and manages a postgres database instance for use by
+#   puppetdb
+#
+# Requires:
+# - `inkling/postgresql`
+#
+# Sample Usage:
+#   include puppetdb::database::postgresql_db
+#
+class puppetdb::database::postgresql_db(
+  $database_name          = $puppetdb::params::database_name,
+  $database_username      = $puppetdb::params::database_username,
+  $database_password      = $puppetdb::params::database_password,
+) inherits puppetdb::params {
+
+  # create the puppetdb database
+  postgresql::db{ $database_name:
+    user     => $database_username,
+    password => $database_password,
+    grant    => 'all',
+    require  => Class['::postgresql::server'],
+  }
+}


### PR DESCRIPTION
Useful to allow more complex setup of the DB server itself while reusing the DB instance creation code.
