### PR TITLE
Use fqdn for ssl listen address instead of clientcert

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,7 @@
 #   ['open_listen_port']   - If true, open the http listen port on the firewall.
 #                            (defaults to false).
 #   ['ssl_listen_address'] - The address that the web server should bind to
-#                            for HTTPS requests.  (defaults to `$::clientcert`.)
+#                            for HTTPS requests.  (defaults to `$::fqdn`.)
 #                            Set to '0.0.0.0' to listen on all addresses.
 #   ['ssl_listen_port']    - The port on which the puppetdb web server should
 #                            accept HTTPS requests (defaults to 8081).

--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -53,7 +53,7 @@
 # TODO: finish porting this to use params
 #
 class puppetdb::master::config(
-  $puppetdb_server          = $::clientcert,
+  $puppetdb_server          = $::fqdn,
   $puppetdb_port            = 8081,
   $manage_routes            = true,
   $manage_storeconfigs      = true,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,7 @@ class puppetdb::params {
   $listen_address            = 'localhost'
   $listen_port               = '8080'
   $open_listen_port          = false
-  $ssl_listen_address        = $::clientcert
+  $ssl_listen_address        = $::fqdn
   $ssl_listen_port           = '8081'
   $disable_ssl               = false
   # This technically defaults to 'true', but in order to preserve backwards

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -30,7 +30,7 @@
 #   ['open_listen_port']   - If true, open the http listen port on the firewall.
 #                            (defaults to false).
 #   ['ssl_listen_address'] - The address that the web server should bind to
-#                            for HTTPS requests.  (defaults to `$::clientcert`.)
+#                            for HTTPS requests.  (defaults to `$::fqdn`.)
 #                            Set to '0.0.0.0' to listen on all addresses.
 #   ['ssl_listen_port']    - The port on which the puppetdb web server should
 #                            accept HTTPS requests (defaults to 8081).

--- a/manifests/server/jetty_ini.pp
+++ b/manifests/server/jetty_ini.pp
@@ -9,7 +9,7 @@
 #   ['listen_port']        - The port on which the puppetdb web server should
 #                            accept HTTP requests (defaults to 8080).
 #   ['ssl_listen_address'] - The address that the web server should bind to
-#                            for HTTPS requests.  (defaults to `$::clientcert`.)
+#                            for HTTPS requests.  (defaults to `$::fqdn`.)
 #   ['ssl_listen_port']    - The port on which the puppetdb web server should
 #                            accept HTTPS requests.
 #   ['disable_ssl']        - If true, disable HTTPS and only serve

--- a/spec/unit/classes/server/jetty_ini_spec.rb
+++ b/spec/unit/classes/server/jetty_ini_spec.rb
@@ -5,7 +5,7 @@ describe 'puppetdb::server::jetty_ini', :type => :class do
     let(:facts) do
       {
         :osfamily                 => 'RedHat',
-        :clientcert               => 'test.domain.local',
+        :fqdn                     => 'test.domain.local',
       }
     end
 


### PR DESCRIPTION
Chris Barker reported that the default value of `$::clientcert`
was not the best choice for some things we were using it for
in the module; specifically, for the default value of
the jetty ssl listen address.  He suggested using `$::fqdn` instead.

This commit makes that change; rspec-system tests pass, but I'm
not 100% sure that there aren't edge cases that would be
affected by this.
