### PR TITLE
Allow puppetdb conn validation when ssl is disabled

### DIFF
--- a/lib/puppet/provider/puppetdb_conn_validator/puppet_https.rb
+++ b/lib/puppet/provider/puppetdb_conn_validator/puppet_https.rb
@@ -50,7 +50,7 @@ Puppet::Type.type(:puppetdb_conn_validator).provide(:puppet_https) do
 
   # @api private
   def validator
-    @validator ||= Puppet::Util::PuppetdbValidator.new(resource[:puppetdb_server], resource[:puppetdb_port])
+    @validator ||= Puppet::Util::PuppetdbValidator.new(resource[:puppetdb_server], resource[:puppetdb_port], resource[:use_ssl])
   end
 
 end

--- a/lib/puppet/type/puppetdb_conn_validator.rb
+++ b/lib/puppet/type/puppetdb_conn_validator.rb
@@ -23,6 +23,11 @@ Puppet::Type.newtype(:puppetdb_conn_validator) do
     desc 'The port that the puppetdb server should be listening on.'
   end
 
+  newparam(:use_ssl) do
+    desc 'Whether the connection will be attemped using https'
+    defaultto true
+  end
+
   newparam(:timeout) do
     desc 'The max number of seconds that the validator should wait before giving up and deciding that puppetdb is not running; defaults to 15 seconds.'
     defaultto 15

--- a/spec/unit/util/puppetdb_validator_spec.rb
+++ b/spec/unit/util/puppetdb_validator_spec.rb
@@ -13,6 +13,8 @@ describe 'Puppet::Util::PuppetdbValidator' do
 
     conn_ok = stub()
     conn_ok.stubs(:get).with('/metrics/mbean/java.lang:type=Memory', {"Accept" => "application/json"}).returns(response_ok)
+    conn_ok.stubs(:read_timeout=).with(2)
+    conn_ok.stubs(:open_timeout=).with(2)
 
     conn_not_found = stub()
     conn_not_found.stubs(:get).with('/metrics/mbean/java.lang:type=Memory', {"Accept" => "application/json"}).returns(response_not_found)
@@ -21,10 +23,17 @@ describe 'Puppet::Util::PuppetdbValidator' do
     Puppet::Network::HttpPool.stubs(:http_instance).with('mypuppetdb.com', 8080, true).raises('Connection refused')
     Puppet::Network::HttpPool.stubs(:http_instance).with('mypuppetdb.com', 8081, true).returns(conn_ok)
     Puppet::Network::HttpPool.stubs(:http_instance).with('wrongserver.com', 8081, true).returns(conn_not_found)
+    Net::HTTP.stubs(:new).with('mypuppetdb.com', 8080).returns(conn_ok)
   end
 
   it 'returns true if connection succeeds' do
     validator = Puppet::Util::PuppetdbValidator.new('mypuppetdb.com', 8081)
+    validator.attempt_connection.should be_true
+  end
+
+  it 'should still validate without ssl' do
+    Puppet[:configtimeout] = 2
+    validator = Puppet::Util::PuppetdbValidator.new('mypuppetdb.com', 8080, false)
     validator.attempt_connection.should be_true
   end
 
@@ -53,4 +62,6 @@ describe 'Puppet::Util::PuppetdbValidator' do
     Puppet.expects(:notice).with("Unable to connect to puppetdb server (#{puppetdb_server}:#{puppetdb_port}): Unknown host")
     validator.attempt_connection.should be_false    
   end
+
+
 end


### PR DESCRIPTION
the puppetdb module allows the usage of https to
be disabled, but the connection validation resource
did not support the ability to verify non https
connections.

This patch introduces a new resource parameter
use_ssl which defaults to true (thus not changing
the current behavior). When set to false, the
connection validation occurs using regular http.
