### PR TITLE
(GH-73) Switch to puppetlabs/inifile from cprice/inifile

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,6 @@
 fixtures:
   repositories:
-    inifile: 'git://github.com/cprice-puppet/puppetlabs-inifile.git'
+    inifile: 'git://github.com/puppetlabs/puppetlabs-inifile.git'
     stdlib: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
     postgresql: 'git://github.com/puppetlabs/puppet-postgresql.git'
     firewall: 'git://github.com/puppetlabs/puppetlabs-firewall.git'

--- a/Modulefile
+++ b/Modulefile
@@ -7,7 +7,7 @@ summary 'PuppetDB resource types'
 license 'ASL 2.0'
 project_page 'https://github.com/puppetlabs/puppetlabs-puppetdb'
 
-dependency 'cprice404/inifile', '>= 0.10.3'
+dependency 'puppetlabs/inifile', '1.x'
 dependency 'puppetlabs/postgresql', '2.x'
 dependency 'puppetlabs/firewall', '>= 0.0.4'
 dependency 'puppetlabs/stdlib', '>= 2.2.0'

--- a/spec/system/basic_spec.rb
+++ b/spec/system/basic_spec.rb
@@ -30,7 +30,7 @@ class { 'puppetdb::master::config': }
       system_run('puppet module install puppetlabs/stdlib')
       system_run('puppet module install puppetlabs/postgresql')
       system_run('puppet module install puppetlabs/firewall')
-      system_run('puppet module install cprice404/inifile')
+      system_run('puppet module install puppetlabs/inifile')
 
       puppet_apply(pp) do |r|
         r[:exit_code].should_not eq(1)


### PR DESCRIPTION
cprice/inifile is deprecated, this patch changes the module to use inifile's
new home puppetlabs/inifile.

Signed-off-by: Ken Barber ken@bob.sh
