### PR TITLE
Add missing parameters for 1.4.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,34 @@ The length of time a node can be deactivated before it's deleted from the databa
 
 The length of time reports should be stored before being deleted. (defaults to '7d', which is a 7-day period). This option is supported in PuppetDB >= 1.1.0.
 
+####`gc_interval`
+
+This controls how often, in minutes, to compact the database. The compaction process reclaims space and deletes unnecessary rows. If not supplied, the default is every 60 minutes.
+
+####`log_slow_statements`
+
+This sets the number of seconds before an SQL query is considered "slow." Slow SQL queries are logged as warnings, to assist in debugging and tuning. Note PuppetDB does not interrupt slow queries; it simply reports them after they complete.
+
+The default value is 10 seconds. A value of 0 will disable logging of slow queries.
+
+####`conn_max_age`
+
+The maximum time (in minutes), for a pooled connection to remain unused before it is closed off.
+
+If not supplied, we default to 60 minutes.
+
+####`conn_keep_alive`
+
+This sets the time (in minutes), for a connection to remain idle before sending a test query to the DB. This is useful to prevent a DB from timing out connections on its end.
+
+If not supplied, we default to 45 minutes.
+
+####`conn_lifetime`
+
+The maximum time (in minutes) a pooled connection should remain open. Any connections older than this setting will be closed off. Connections currently in use will not be affected until they are returned to the pool.
+
+If not supplied, we won't terminate connections based on their age alone.
+
 ####`puppetdb_package`
 
 The puppetdb package name in the package manager.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,3 @@
-# Class: puppetdb
-#
 # This class provides a simple way to get a puppetdb instance up and running
 # with minimal effort.  It will install and configure all necessary packages,
 # including the database server and instance.
@@ -13,81 +11,6 @@
 #
 # In addition to this class, you'll need to configure your puppet master to use
 # puppetdb.  You can use the `puppetdb::master::config` class to accomplish this.
-#
-# Parameters:
-#   ['listen_address']     - The address that the web server should bind to
-#                            for HTTP requests.  (defaults to `localhost`.
-#                            '0.0.0.0' = all)
-#   ['listen_port']        - The port on which the puppetdb web server should
-#                            accept HTTP requests (defaults to 8080).
-#   ['open_listen_port']   - If true, open the http listen port on the firewall.
-#                            (defaults to false).
-#   ['ssl_listen_address'] - The address that the web server should bind to
-#                            for HTTPS requests.  (defaults to `$::fqdn`.)
-#                            Set to '0.0.0.0' to listen on all addresses.
-#   ['ssl_listen_port']    - The port on which the puppetdb web server should
-#                            accept HTTPS requests (defaults to 8081).
-#   ['disable_ssl']        - If true, disable HTTPS and only serve
-#                            HTTP requests. Defaults to false.
-#   ['open_ssl_listen_port'] - If true, open the ssl listen port on the firewall.
-#                            (defaults to true).
-#   ['database']           - Which database backend to use; legal values are
-#                            `postgres` (default) or `embedded`.  (The `embedded`
-#                            db can be used for very small installations or for
-#                            testing, but is not recommended for use in production
-#                            environments.  For more info, see the puppetdb docs.)
-#   ['database_port']      - The port that the database server listens on.
-#                            (defaults to `5432`; ignored for `embedded` db)
-#   ['database_username']  - The name of the database user to connect as.
-#                            (defaults to `puppetdb`; ignored for `embedded` db)
-#   ['database_password']  - The password for the database user.
-#                            (defaults to `puppetdb`; ignored for `embedded` db)
-#   ['database_name']      - The name of the database instance to connect to.
-#                            (defaults to `puppetdb`; ignored for `embedded` db)
-#   ['node_ttl']           - The length of time a node can go without receiving
-#                            any new data before it's automatically deactivated.
-#                            (defaults to '0', which disables auto-deactivation)
-#                            This option is supported in PuppetDB >= 1.1.0.
-#   ['node_purge_ttl']     - The length of time a node can be deactivated before
-#                            it's deleted from the database.
-#                            (defaults to '0', which disables purging)
-#                            This option is supported in PuppetDB >= 1.2.0.
-#   ['report_ttl']         - The length of time reports should be stored before
-#                            being deleted.
-#                            (defaults to '7d', which is a 7-day period)
-#                            This option is supported in PuppetDB >= 1.1.0.
-#   ['open_postgres_port'] - If true, open the postgres port on the firewall.
-#                            (defaults to true).
-#   ['puppetdb_package']   - The puppetdb package name in the package manager
-#   ['puppetdb_version']   - The version of the `puppetdb` package that should
-#                            be installed.  You may specify an explicit version
-#                            number, 'present', or 'latest'.  (defaults to
-#                            'present')
-#   ['puppetdb_service']   - The name of the puppetdb service.
-#   ['manage_redhat_firewall'] - DEPRECATED: Use open_ssl_listen_port instead.
-#                            boolean indicating whether or not the module
-#                            should open a port in the firewall on redhat-based
-#                            systems.  Defaults to `false`.  This parameter is
-#                            likely to change in future versions.  Possible
-#                            changes include support for non-RedHat systems and
-#                            finer-grained control over the firewall rule
-#                            (currently, it simply opens up the postgres port to
-#                            all TCP connections).
-#   ['confdir']            - The puppetdb configuration directory; defaults to
-#                            `/etc/puppetdb/conf.d`.
-#   ['java_args']          - Java VM options used for overriding default Java VM
-#                            options specified in PuppetDB package.
-#                            (defaults to `{}`).
-#                            e.g. { '-Xmx' => '512m', '-Xms' => '256m' }
-# Actions:
-# - Creates and manages a puppetdb server and its database server/instance.
-#
-# Requires:
-# - `inkling/postgresql`
-#
-# Sample Usage:
-#   include puppetdb
-#
 class puppetdb(
   $listen_address            = $puppetdb::params::listen_address,
   $listen_port               = $puppetdb::params::listen_port,
@@ -104,6 +27,11 @@ class puppetdb(
   $node_ttl                  = $puppetdb::params::node_ttl,
   $node_purge_ttl            = $puppetdb::params::node_purge_ttl,
   $report_ttl                = $puppetdb::params::report_ttl,
+  $gc_interval               = $puppetdb::params::gc_interval,
+  $log_slow_statements       = $puppetdb::params::log_slow_statements,
+  $conn_max_age              = $puppetdb::params::conn_max_age,
+  $conn_keep_alive           = $puppetdb::params::conn_keep_alive,
+  $conn_lifetime             = $puppetdb::params::conn_lifetime,
   $puppetdb_package          = $puppetdb::params::puppetdb_package,
   $puppetdb_version          = $puppetdb::params::puppetdb_version,
   $puppetdb_service          = $puppetdb::params::puppetdb_service,
@@ -163,6 +91,7 @@ class puppetdb(
     node_ttl               => $node_ttl,
     node_purge_ttl         => $node_purge_ttl,
     report_ttl             => $report_ttl,
+    gc_interval            => $gc_interval,
     puppetdb_package       => $puppetdb_package,
     puppetdb_version       => $puppetdb_version,
     puppetdb_service       => $puppetdb_service,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,15 +1,4 @@
-# Class: puppetdb::params
-#
-#   The puppetdb configuration settings.
-#
-# Parameters:
-#
-# Actions:
-#
-# Requires:
-#
-# Sample Usage:
-#
+# The puppetdb default configuration settings.
 class puppetdb::params {
   $listen_address            = 'localhost'
   $listen_port               = '8080'
@@ -53,6 +42,11 @@ class puppetdb::params {
   $manage_redhat_firewall = undef
 
   $gc_interval            = '60'
+
+  $log_slow_statements    = '10'
+  $conn_max_age           = '60'
+  $conn_keep_alive        = '45'
+  $conn_lifetime          = '0'
 
   case $::osfamily {
     'RedHat': {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,5 +1,3 @@
-# Class: puppetdb::server
-#
 # This class provides a simple way to get a puppetdb instance up and running
 # with minimal effort.  It will install and configure all necessary packages for
 # the puppetdb server, but will *not* manage the database (e.g., postgres) server
@@ -20,83 +18,6 @@
 #
 # You'll also need to configure your puppet master to use puppetdb.  You can
 # use the `puppetdb::master::config` class to accomplish this.
-#
-# Parameters:
-#   ['listen_address']     - The address that the web server should bind to
-#                            for HTTP requests.  (defaults to `localhost`.)
-#                            Set to '0.0.0.0' to listen on all addresses.
-#   ['listen_port']        - The port on which the puppetdb web server should
-#                            accept HTTP requests (defaults to 8080).
-#   ['open_listen_port']   - If true, open the http listen port on the firewall.
-#                            (defaults to false).
-#   ['ssl_listen_address'] - The address that the web server should bind to
-#                            for HTTPS requests.  (defaults to `$::fqdn`.)
-#                            Set to '0.0.0.0' to listen on all addresses.
-#   ['ssl_listen_port']    - The port on which the puppetdb web server should
-#                            accept HTTPS requests (defaults to 8081).
-#   ['disable_ssl']        - If true, disable HTTPS and only serve
-#                            HTTP requests. Defaults to false.
-#   ['open_ssl_listen_port'] - If true, open the ssl listen port on the firewall.
-#                            (defaults to true).
-#   ['database']           - Which database backend to use; legal values are
-#                            `postgres` (default) or `embedded`.  (The `embedded`
-#                            db can be used for very small installations or for
-#                            testing, but is not recommended for use in production
-#                            environments.  For more info, see the puppetdb docs.)
-#   ['database_host']      - The hostname or IP address of the database server.
-#                            (defaults to `localhost`; ignored for `embedded` db)
-#   ['database_port']      - The port that the database server listens on.
-#                            (defaults to `5432`; ignored for `embedded` db)
-#   ['database_username']  - The name of the database user to connect as.
-#                            (defaults to `puppetdb`; ignored for `embedded` db)
-#   ['database_password']  - The password for the database user.
-#                            (defaults to `puppetdb`; ignored for `embedded` db)
-#   ['database_name']      - The name of the database instance to connect to.
-#                            (defaults to `puppetdb`; ignored for `embedded` db)
-#   ['node_ttl']           - The length of time a node can go without receiving
-#                            any new data before it's automatically deactivated.
-#                            (defaults to '0', which disables auto-deactivation)
-#                            This option is supported in PuppetDB >= 1.1.0.
-#   ['node_purge_ttl']     - The length of time a node can be deactivated before
-#                            it's deleted from the database.
-#                            (defaults to '0', which disables purging)
-#                            This option is supported in PuppetDB >= 1.2.0.
-#   ['report_ttl']         - The length of time reports should be stored before
-#                            being deleted.
-#                            (defaults to '7d', which is a 7-day period)
-#                            This option is supported in PuppetDB >= 1.1.0.
-#   ['puppetdb_package']   - The puppetdb package name in the package manager
-#   ['puppetdb_version']   - The version of the `puppetdb` package that should
-#                            be installed.  You may specify an explicit version
-#                            number, 'present', or 'latest'.  Defaults to
-#                            'present'.
-#   ['puppetdb_service']   - The name of the puppetdb service.
-#   ['manage_redhat_firewall'] - DEPRECATED: Use open_ssl_listen_port instead.
-#                            boolean indicating whether or not the module
-#                            should open a port in the firewall on redhat-based
-#                            systems.  Defaults to `true`.  This parameter is
-#                            likely to change in future versions.  Possible
-#                            changes include support for non-RedHat systems and
-#                            finer-grained control over the firewall rule
-#                            (currently, it simply opens up the postgres port to
-#                            all TCP connections).
-#   ['confdir']            - The puppetdb configuration directory; defaults to
-#                            `/etc/puppetdb/conf.d`.
-#   ['java_args']          - Java VM options used for overriding default Java VM
-#                            options specified in PuppetDB package.
-#                            (defaults to `{}`).
-#                            e.g. { '-Xmx' => '512m', '-Xms' => '256m' }
-# Actions:
-# - Creates and manages a puppetdb server
-#
-# Requires:
-# - `inkling/postgresql`
-#
-# Sample Usage:
-#     class { 'puppetdb::server':
-#         database_host     => 'puppetdb-postgres',
-#     }
-#
 class puppetdb::server(
   $listen_address          = $puppetdb::params::listen_address,
   $listen_port             = $puppetdb::params::listen_port,
@@ -114,6 +35,11 @@ class puppetdb::server(
   $node_ttl                = $puppetdb::params::node_ttl,
   $node_purge_ttl          = $puppetdb::params::node_purge_ttl,
   $report_ttl              = $puppetdb::params::report_ttl,
+  $gc_interval             = $puppetdb::params::gc_interval,
+  $log_slow_statements     = $puppetdb::params::log_slow_statements,
+  $conn_max_age            = $puppetdb::params::conn_max_age,
+  $conn_keep_alive         = $puppetdb::params::conn_keep_alive,
+  $conn_lifetime           = $puppetdb::params::lifetime,
   $puppetdb_package        = $puppetdb::params::puppetdb_package,
   $puppetdb_version        = $puppetdb::params::puppetdb_version,
   $puppetdb_service        = $puppetdb::params::puppetdb_service,
@@ -175,6 +101,11 @@ class puppetdb::server(
     node_ttl          => $node_ttl,
     node_purge_ttl    => $node_purge_ttl,
     report_ttl        => $report_ttl,
+    gc_interval       => $gc_interval,
+    log_slow_statements => $log_slow_statements,
+    conn_max_age      => $conn_max_age,
+    conn_keep_alive   => $conn_keep_alive,
+    conn_lifetime     => $conn_lifetime,
     confdir           => $confdir,
     notify            => Service[$puppetdb_service],
   }

--- a/manifests/server/database_ini.pp
+++ b/manifests/server/database_ini.pp
@@ -1,41 +1,4 @@
-# Class: puppetdb::server::database_ini
-#
 # This class manages puppetdb's `database.ini` file.
-#
-# Parameters:
-#   ['database']        - Which database backend to use; legal values are
-#                         `postgres` (default) or `embedded`.  (The `embedded`
-#                         db can be used for very small installations or for
-#                         testing, but is not recommended for use in production
-#                         environments.  For more info, see the puppetdb docs.)
-#   ['database_host']   - The hostname or IP address of the database server.
-#                         (defaults to `localhost`; ignored for `embedded` db)
-#   ['database_port']   - The port that the database server listens on.
-#                         (defaults to `5432`; ignored for `embedded` db)
-#   ['database_user']   - The name of the database user to connect as.
-#                         (defaults to `puppetdb`; ignored for `embedded` db)
-#   ['database_password'] - The password for the database user.
-#                         (defaults to `puppetdb`; ignored for `embedded` db)
-#   ['database_name']   - The name of the database instance to connect to.
-#                         (defaults to `puppetdb`; ignored for `embedded` db)
-#   ['confdir']         - The puppetdb configuration directory; defaults to
-#                         `/etc/puppetdb/conf.d`.
-#
-# Actions:
-# - Manages puppetdb's `database.ini` file
-#
-# Requires:
-# - Inifile
-#
-# Sample Usage:
-#   class { 'puppetdb::server::database_ini':
-#     database_host     => 'my.postgres.host',
-#     database_port     => '5432',
-#     database_username => 'puppetdb_pguser',
-#     database_password => 'puppetdb_pgpasswd',
-#     database_name     => 'puppetdb',
-#   }
-#
 class puppetdb::server::database_ini(
   $database          = $puppetdb::params::database,
   $database_host     = $puppetdb::params::database_host,
@@ -47,6 +10,10 @@ class puppetdb::server::database_ini(
   $node_purge_ttl    = $puppetdb::params::node_purge_ttl,
   $report_ttl        = $puppetdb::params::report_ttl,
   $gc_interval       = $puppetdb::params::gc_interval,
+  $log_slow_statements = $puppetdb::params::log_slow_statements,
+  $conn_max_age      = $puppetdb::params::conn_max_age,
+  $conn_keep_alive   = $puppetdb::params::conn_keep_alive,
+  $conn_lifetime     = $puppetdb::params::conn_lifetime,
   $confdir           = $puppetdb::params::confdir,
 ) inherits puppetdb::params {
 
@@ -131,5 +98,25 @@ class puppetdb::server::database_ini(
   ini_setting {'puppetdb_report_ttl':
     setting => 'report-ttl',
     value   => $report_ttl,
+  }
+
+  ini_setting {'puppetdb_log_slow_statements':
+    setting => 'log-slow-statements',
+    value   => $log_slow_statements,
+  }
+
+  ini_setting {'puppetdb_conn_max_age':
+    setting => 'conn-max-age',
+    value   => $conn_max_age,
+  }
+
+  ini_setting {'puppetdb_conn_keep_alive':
+    setting => 'conn-keep-alive',
+    value   => $conn_keep_alive,
+  }
+
+  ini_setting {'puppetdb_conn_lifetime':
+    setting => 'conn-lifetime',
+    value   => $conn_lifetime,
   }
 }


### PR DESCRIPTION
This patch adds all the missing parameters now defined in the 1.4.0 release.

This includes some new database parameters mainly, but also adds gc_interval
to the `puppetdb` and `puppetdb::server` classes, as previously this wasn't
configurable using this method.

To avoid documentation duplication the Puppet headers have been removed in
favour of documenting classes from the README.md. Until such times as the
forge can turn Puppet docs into HTML automatically, this is just duplicate
noise and prone to update slippage. The README.md is more authoritative in
this area and is pubicly displayed on the forge project page so it should be
used for now.

Signed-off-by: Ken Barber ken@bob.sh
