### PR TITLE
Make database_password an optional parameter

### DIFF
--- a/manifests/server/database_ini.pp
+++ b/manifests/server/database_ini.pp
@@ -87,9 +87,11 @@ class puppetdb::server::database_ini(
       value   => $database_username,
     }
 
-    ini_setting {'puppetdb_psdatabase_password':
-      setting => 'password',
-      value   => $database_password,
+    if $database_password != undef {
+      ini_setting {'puppetdb_psdatabase_password':
+        setting => 'password',
+        value   => $database_password,
+      }
     }
   }
 

--- a/manifests/server/validate_db.pp
+++ b/manifests/server/validate_db.pp
@@ -52,7 +52,7 @@ class puppetdb::server::validate_db(
 ) inherits puppetdb::params {
 
   # We don't need any validation for the embedded database, presumably.
-  if ($database == 'postgres') {
+  if ($database == 'postgres' and $database_password != undef) {
     postgresql::validate_db_connection { 'validate puppetdb postgres connection':
       database_host     => $database_host,
       database_port     => $database_port,


### PR DESCRIPTION
In some cases it may not be possible to securely specify a password for 
PuppetDB. When that is true, it's impossible to use the module to manage 
PuppetDB, because specifying undef for the password will cause database 
validation to fail, or for the setting in database.ini to be overridden.

This change will simply check that database_password is set, and will skip
validation and changing database.ini in the case where it is not.
