### PR TITLE
Pin fixtures to use postgresql 2.5.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,9 @@ fixtures:
   repositories:
     inifile: 'git://github.com/puppetlabs/puppetlabs-inifile.git'
     stdlib: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
-    postgresql: 'git://github.com/puppetlabs/puppet-postgresql.git'
+    postgresql:
+      repo: 'git://github.com/puppetlabs/puppet-postgresql.git'
+      ref: '2.5.0'
     firewall: 'git://github.com/puppetlabs/puppetlabs-firewall.git'
     apt: 'git://github.com/puppetlabs/puppetlabs-apt.git'
     concat: 'git://github.com/ripienaar/puppet-concat.git'


### PR DESCRIPTION
Unfortunately postgresql master is not compatible with this module yet, so to
avoid errors during testing we are having to pin the revision of postgresql
we pull down.

Unfortunately again, puppetlabs_spec_helper doesn't yet support branches, so
we're pinning on a specific revision for now.

This can be removed once we are modified to be compatible with the newly
released postgresql module.

Signed-off-by: Ken Barber ken@bob.sh
