### PR TITLE
This will pin the installation of puppetlabs/postgresql to version 2.5.0

### DIFF
--- a/spec/system/basic_spec.rb
+++ b/spec/system/basic_spec.rb
@@ -28,7 +28,7 @@ class { 'puppetdb::master::config': }
 
     it 'make sure it runs without error' do
       system_run('puppet module install puppetlabs/stdlib')
-      system_run('puppet module install puppetlabs/postgresql')
+      system_run('puppet module install puppetlabs/postgresql --version 2.5.0')
       system_run('puppet module install puppetlabs/firewall')
       system_run('puppet module install puppetlabs/inifile')
 


### PR DESCRIPTION
Since version 3.0.0 is now released, we want to pin against the old revision
everywhere. We already pin in the Modulefile and unit tests, we just forgot
to do it for the rspec-system tests.

Signed-off-by: Ken Barber ken@bob.sh
