### PR TITLE
Allow puppetdb::master::config class to perform puppetdb conn validation without SSL.

### DIFF
--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -2,13 +2,13 @@
 class puppetdb::master::config(
   $puppetdb_server             = $::fqdn,
   $puppetdb_port               = 8081,
-  $use_ssl                     = true,
   $puppetdb_soft_write_failure = false,
   $manage_routes               = true,
   $manage_storeconfigs         = true,
   $manage_report_processor     = false,
   $manage_config               = true,
   $strict_validation           = true,
+  $validate_using_ssl          = true,
   $enable_reports              = false,
   $puppet_confdir              = $puppetdb::params::puppet_confdir,
   $puppet_conf                 = $puppetdb::params::puppet_conf,
@@ -29,7 +29,7 @@ class puppetdb::master::config(
     puppetdb_conn_validator { 'puppetdb_conn':
       puppetdb_server => $manage_config ? { true => $puppetdb_server, default => undef },
       puppetdb_port   => $manage_config ? { true => $puppetdb_port, default => undef },
-      use_ssl         => $manage_config ? { true => $use_ssl, default => undef },
+      use_ssl         => $validate_using_ssl,
       timeout         => $puppetdb_startup_timeout,
       require         => Package[$terminus_package],
     }

--- a/spec/unit/classes/master/config_spec.rb
+++ b/spec/unit/classes/master/config_spec.rb
@@ -11,35 +11,35 @@ describe 'puppetdb::master::config', :type => :class do
     end
 
     describe 'when validating the puppetdb connection' do
-      context 'with manage config set to true' do
+      context 'with validate using ssl' do
         let(:params) do
           {
-            'manage_config' => true,
+            'validate_using_ssl' => true,
           }
         end
 
         it { should contain_puppetdb_conn_validator('puppetdb_conn').with(
-          'puppetdb_server'     => 'test.domain.local',
-          'puppetdb_port'       => 8081,
-          'use_ssl'             => true,
-          'timeout'             => 120,
-          'require'             => 'Package[puppetdb-terminus]'
+          'puppetdb_server'      => 'test.domain.local',
+          'puppetdb_port'        => 8081,
+          'use_ssl'              => true,
+          'timeout'              => 120,
+          'require'              => 'Package[puppetdb-terminus]'
         )}
       end
 
-      context 'with manage config set to false' do
+      context 'without validate using ssl' do
         let(:params) do
           {
-            'manage_config' => false,
+            'validate_using_ssl' => false,
           }
         end
 
         it { should contain_puppetdb_conn_validator('puppetdb_conn').with(
-          'puppetdb_server'     => nil,
-          'puppetdb_port'       => nil,
-          'use_ssl'             => nil,
-          'timeout'             => 120,
-          'require'             => 'Package[puppetdb-terminus]'
+          'puppetdb_server'      => 'test.domain.local',
+          'puppetdb_port'        => 8081,
+          'use_ssl'              => false,
+          'timeout'              => 120,
+          'require'              => 'Package[puppetdb-terminus]'
         )}
       end
     end


### PR DESCRIPTION
Here is a fix for the Issue #98 that I created.  I added a unit test for the specific part that I was concerned about.  There was previously no config_spec.rb file so I created one.

Let me know if this is ok or if I am missing something completely and there is another way to achieve what I mentioned in Issue #98.
