### PR TITLE
fix validation regular expressions

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,7 +39,7 @@ class puppetdb(
   }
 
   # Validate node_ttl
-  validate_re ($node_ttl_real, ['^(\d)+[s,m,d]$'], "node_ttl is <${node_ttl}> which does not match the regex validation")
+  validate_re ($node_ttl_real, ['^\d+(d|h|m|s|ms)$'], "node_ttl is <${node_ttl}> which does not match the regex validation")
 
   # Apply necessary suffix if zero is specified.
   if $node_purge_ttl == '0' {
@@ -49,7 +49,7 @@ class puppetdb(
   }
 
   # Validate node_purge_ttl
-  validate_re ($node_purge_ttl_real, ['^(\d)+[s,m,d]$'], "node_purge_ttl is <${node_purge_ttl}> which does not match the regex validation")
+  validate_re ($node_purge_ttl_real, ['^\d+(d|h|m|s|ms)$'], "node_purge_ttl is <${node_purge_ttl}> which does not match the regex validation")
 
   # Apply necessary suffix if zero is specified.
   if $report_ttl == '0' {
@@ -59,7 +59,7 @@ class puppetdb(
   }
 
   # Validate report_ttl
-  validate_re ($report_ttl_real, ['^(\d)+[s,m,d]$'], "report_ttl is <${report_ttl}> which does not match the regex validation")
+  validate_re ($report_ttl_real, ['^\d+(d|h|m|s|ms)$'], "report_ttl is <${report_ttl}> which does not match the regex validation")
 
   # Validate puppetdb_service_status
   if !($puppetdb_service_status in ['true', 'running', 'false', 'stopped']) {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -38,7 +38,7 @@ class puppetdb::server(
   }
 
   # Validate node_ttl
-  validate_re ($node_ttl_real, ['^(\d)+[s,m,d]$'], "node_ttl is <${node_ttl}> which does not match the regex validation")
+  validate_re ($node_ttl_real, ['^\d+(d|h|m|s|ms)$'], "node_ttl is <${node_ttl}> which does not match the regex validation")
 
   # Apply necessary suffix if zero is specified.
   if $node_purge_ttl == '0' {
@@ -48,7 +48,7 @@ class puppetdb::server(
   }
 
   # Validate node_purge_ttl
-  validate_re ($node_purge_ttl_real, ['^(\d)+[s,m,d]$'], "node_purge_ttl is <${node_purge_ttl}> which does not match the regex validation")
+  validate_re ($node_purge_ttl_real, ['^\d+(d|h|m|s|ms)$'], "node_purge_ttl is <${node_purge_ttl}> which does not match the regex validation")
 
   # Apply necessary suffix if zero is specified.
   if $report_ttl == '0' {
@@ -58,7 +58,7 @@ class puppetdb::server(
   }
 
   # Validate report_ttl
-  validate_re ($report_ttl_real, ['^(\d)+[s,m,d]$'], "report_ttl is <${report_ttl}> which does not match the regex validation")
+  validate_re ($report_ttl_real, ['^\d+(d|h|m|s|ms)$'], "report_ttl is <${report_ttl}> which does not match the regex validation")
 
   # Validate puppetdb_service_status
   if !($puppetdb_service_status in ['true', 'running', 'false', 'stopped']) {


### PR DESCRIPTION
The previous validations of times did not allow for specifying units of "h" or "ms", which are valid for puppetdb, but did allow for units of ",", which are not valid for puppetdb.  This fixes both problems.
