### PR TITLE
Support rspec-puppet v1.0.0

### DIFF
--- a/spec/unit/classes/master/report_processor_spec.rb
+++ b/spec/unit/classes/master/report_processor_spec.rb
@@ -9,7 +9,7 @@ describe 'puppetdb::master::report_processor', :type => :class do
       }
     end
 
-    it { should include_class('puppetdb::master::report_processor') }
+    it { should contain_class('puppetdb::master::report_processor') }
 
     describe 'when using default values' do
       it { should contain_ini_subsetting('puppet.conf/reports/puppetdb').

--- a/spec/unit/classes/server/jetty_ini_spec.rb
+++ b/spec/unit/classes/server/jetty_ini_spec.rb
@@ -9,7 +9,7 @@ describe 'puppetdb::server::jetty_ini', :type => :class do
       }
     end
 
-    it { should include_class('puppetdb::server::jetty_ini') }
+    it { should contain_class('puppetdb::server::jetty_ini') }
 
     describe 'when using default values' do
       it { should contain_ini_setting('puppetdb_host').


### PR DESCRIPTION
include_class has been replaced with contain_class.
http://bombasticmonkey.com/2013/12/05/rspec-puppet-1.0.0/
