### PR TITLE
Ensure db and db users created before validation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -104,7 +104,7 @@ class puppetdb(
       database_name          => $database_name,
       database_username      => $database_username,
       database_password      => $database_password,
-      before                 => Class['puppetdb::server']
+      before                 => [Class['puppetdb::server'],Class['puppetdb::server::validate_db']],
     }
   }
 }


### PR DESCRIPTION
Ensure that for PostgreSQL backends, the database validation functions
are not run until the initial database creation and user role creation
has been completed.

Closes-Bug: #1298605
