### PR TITLE
add parameter 'max_threads' to define value in jetty.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ The address that the web server should bind to for HTTP requests (defaults to `l
 
 The port on which the puppetdb web server should accept HTTP requests (defaults to '8080').
 
+####`max_threads`
+
+This sets the maximum number of threads assigned to responding to HTTP and HTTPS requests, effectively changing how many concurrent requests can be made at one time. (defaults to 50).
+
 ####`open_listen_port`
 
 If true, open the http_listen\_port on the firewall (defaults to false).

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,6 +2,7 @@
 class puppetdb::params {
   $listen_address            = 'localhost'
   $listen_port               = '8080'
+  $max_threads               = '50'
   $open_listen_port          = false
   $ssl_listen_address        = $::fqdn
   $ssl_listen_port           = '8081'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -2,6 +2,7 @@
 class puppetdb::server(
   $listen_address          = $puppetdb::params::listen_address,
   $listen_port             = $puppetdb::params::listen_port,
+  $max_threads             = $puppetdb::params::max_threads,
   $open_listen_port        = $puppetdb::params::open_listen_port,
   $ssl_listen_address      = $puppetdb::params::ssl_listen_address,
   $ssl_listen_port         = $puppetdb::params::ssl_listen_port,
@@ -104,6 +105,7 @@ class puppetdb::server(
   class { 'puppetdb::server::jetty_ini':
     listen_address      => $listen_address,
     listen_port         => $listen_port,
+    max_threads         => $max_threads,
     ssl_listen_address  => $ssl_listen_address,
     ssl_listen_port     => $ssl_listen_port,
     disable_ssl         => $disable_ssl,

--- a/manifests/server/jetty_ini.pp
+++ b/manifests/server/jetty_ini.pp
@@ -2,6 +2,7 @@
 class puppetdb::server::jetty_ini(
   $listen_address     = $puppetdb::params::listen_address,
   $listen_port        = $puppetdb::params::listen_port,
+  $max_threads        = $puppetdb::params::max_threads,
   $ssl_listen_address = $puppetdb::params::ssl_listen_address,
   $ssl_listen_port    = $puppetdb::params::ssl_listen_port,
   $disable_ssl        = $puppetdb::params::disable_ssl,
@@ -26,6 +27,11 @@ class puppetdb::server::jetty_ini(
   ini_setting {'puppetdb_port':
     setting => 'port',
     value   => $listen_port,
+  }
+
+  ini_setting {'puppetdb_maxthreads':
+    setting => 'max-threads',
+    value   => $max_threads,
   }
 
   $ssl_setting_ensure = $disable_ssl ? {

--- a/spec/unit/classes/server/jetty_ini_spec.rb
+++ b/spec/unit/classes/server/jetty_ini_spec.rb
@@ -28,6 +28,14 @@ describe 'puppetdb::server::jetty_ini', :type => :class do
              'setting' => 'port',
              'value'   => 8080
              )}
+      it { should contain_ini_setting('puppetdb_maxthreads').
+        with(
+             'ensure'  => 'present',
+             'path'    => '/etc/puppetdb/conf.d/jetty.ini',
+             'section' => 'jetty',
+             'setting' => 'max-threads',
+             'value'   => 50
+             )}
       it { should contain_ini_setting('puppetdb_sslhost').
         with(
              'ensure'  => 'present',


### PR DESCRIPTION
Dear Puppetlabs Team,

do you mind merging our changes for puppetdb module? It became necessary recently as we updated to puppetdb 2.0 and our 214 hosts were trying to connect simultaneously. If you are interested in more detail, we are happy to send them over.

Thanks
Mathias
