### PR TITLE
do not manage firewall for postgres, puppetlabs/postgres module from

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,10 +460,6 @@ The `puppetdb::database::postgresql` class manages a postgresql server for use b
 
 The `listen_address` is a comma-separated list of hostnames or IP addresses on which the postgres server should listen for incoming connections. This defaults to `localhost`. This parameter maps directly to postgresql's `listen_addresses` config option; use a `*` to allow connections on any accessible address.
 
-####`manage_firewall`
-
-If set to `true` this will enable open the local firewall for PostgreSQL protocol access. Defaults to `false`.
-
 ####`database_name`
 
 Sets the name of the database. Defaults to `puppetdb`.

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -1,7 +1,6 @@
 # Class for creating the PuppetDB postgresql database. See README.md for more
 # information.
 class puppetdb::database::postgresql(
-  $manage_firewall   = $puppetdb::params::open_postgres_port,
   $listen_addresses  = $puppetdb::params::database_host,
   $database_name     = $puppetdb::params::database_name,
   $database_username = $puppetdb::params::database_username,
@@ -14,7 +13,6 @@ class puppetdb::database::postgresql(
     class { '::postgresql::server':
       ip_mask_allow_all_users => '0.0.0.0/0',
       listen_addresses        => $listen_addresses,
-      manage_firewall         => $manage_firewall,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,7 +39,6 @@ class puppetdb(
   $read_conn_max_age         = $puppetdb::params::read_conn_max_age,
   $read_conn_keep_alive      = $puppetdb::params::read_conn_keep_alive,
   $read_conn_lifetime        = $puppetdb::params::read_conn_lifetime,
-  $open_postgres_port        = $puppetdb::params::open_postgres_port,
   $confdir                   = $puppetdb::params::confdir,
   $java_args                 = {},
   $max_threads               = $puppetdb::params::max_threads
@@ -124,7 +123,6 @@ class puppetdb(
 
   if ($database == 'postgres') {
     class { 'puppetdb::database::postgresql':
-      manage_firewall        => $open_postgres_port,
       listen_addresses       => $database_listen_address,
       database_name          => $database_name,
       database_username      => $database_username,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,6 @@ class puppetdb::params {
   $disable_ssl               = false
   $open_ssl_listen_port      = undef
   $postgres_listen_addresses = 'localhost'
-  $open_postgres_port        = undef
 
   $database                  = 'postgres'
   $manage_dbserver           = true


### PR DESCRIPTION
git has dropped that silly firewall management support.

Using the git version of puppetlabs/puppetdb together with git version of puppetlabs/postgres then you get this error:
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Invalid parameter manage_firewall on Class[Postgresql::Server] at /etc/puppet/environments/production/modules/puppetdb/manifests/database/postgresql.pp:18 on node

patch below removes management of firewall ports for the postgresql database.
