### PR TITLE
OpenBSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ Platforms:
 * Debian 6
 * Ubuntu 10.04
 * Archlinux
+* OpenBSD 5.6-current and newer
 
 Development
 ------------

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -90,17 +90,24 @@ class puppetdb::params {
     $puppetdb_package     = 'puppetdb'
     $puppetdb_service     = 'puppetdb'
     $confdir              = '/etc/puppetdb/conf.d'
-    $puppet_service_name  = 'puppetmaster'
     $puppet_confdir       = '/etc/puppet'
     $terminus_package     = 'puppetdb-terminus'
-    $embedded_subname     = 'file:/usr/share/puppetdb/db/db;hsqldb.tx=mvcc;sql.syntax_pgs=true'
 
     case $::osfamily {
       'RedHat', 'Suse', 'Archlinux': {
-        $puppetdb_initconf = '/etc/sysconfig/puppetdb'
+        $puppetdb_initconf    = '/etc/sysconfig/puppetdb'
+        $puppet_service_name  = 'puppetmaster'
+        $embedded_subname     = 'file:/usr/share/puppetdb/db/db;hsqldb.tx=mvcc;sql.syntax_pgs=true'
       }
       'Debian': {
-        $puppetdb_initconf = '/etc/default/puppetdb'
+        $puppetdb_initconf    = '/etc/default/puppetdb'
+        $puppet_service_name  = 'puppetmaster'
+        $embedded_subname     = 'file:/usr/share/puppetdb/db/db;hsqldb.tx=mvcc;sql.syntax_pgs=true'
+      }
+      'OpenBSD': {
+        $puppetdb_initconf    = undef
+        $puppet_service_name  = 'puppetmasterd'
+        $embedded_subname     = 'file:/var/db/puppetdb/db/db;hsqldb.tx=mvcc;sql.syntax_pgs=true'
       }
       default: {
         fail("${module_name} supports osfamily's RedHat and Debian. Your osfamily is recognized as ${::osfamily}")


### PR DESCRIPTION
Patch below adds support for OpenBSD. 

Due to differences, the puppet_service_name and embedded_subname had to be made dependent on osfamily.

Note: This only adds support for OpenBSD 5.6-current, which means, needs at least puppetdb-2.1.0p1 package 
installed on OpenBSD. Prior versions had a single puppetdb/conf.d/puppetdb.conf file, instead of the
multiple configuration files. 

Note: To make the change below work, my pull request for OpenBSD support to puppetlabs/postgresql needs to be added to that module.
