### PR TITLE
Cleanups, missing doc items and new test_url capability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,11 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 group :development, :test do
   gem 'rake'
   gem 'puppetlabs_spec_helper', :require => false
-  gem 'rspec-puppet', '~>1.0'
-  gem 'puppet-lint', '~> 0.3.2'
-  gem 'beaker',                  :require => false
-  gem 'beaker-rspec',            :require => false
-  gem 'serverspec',              :require => false
+  gem 'beaker',                 :require => false
+  gem 'beaker-rspec',           :require => false
+  gem 'serverspec',             :require => false
+  gem 'rspec-puppet', '~> 1.0'
+  gem 'puppet-lint',  '~> 1.1'
 end
 
 if puppetversion = ENV['PUPPET_GEM_VERSION']

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Puppet PuppetDB Module - Puppet module for managing PuppetDB
 
-Copyright (C) 2012-2013 Puppet Labs, Inc.
+Copyright (C) 2012-2014 Puppet Labs, Inc.
 
 Puppet Labs can be contacted at: info@puppetlabs.com

--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ If true, the PostgreSQL server will be managed by this module (defaults to true)
 
 Which database backend to use; legal values are `postgres` (default) or `embedded`. The `embedded` db can be used for very small installations or for testing, but is not recommended for use in production environments. For more info, see the [puppetdb docs](http://docs.puppetlabs.com/puppetdb/).
 
+####`database_host`
+
+Hostname to use for the database connection. For single case installations this should be left as the default. (defaults to `localhost`; ignored for `embedded` db).
+
 ####`database_port`
 
 The port that the database server listens on (defaults to `5432`; ignored for `embedded` db).
@@ -370,22 +374,50 @@ The maximum time (in minutes) a pooled read database connection should remain op
 
 If not supplied, we won't terminate connections based on their age alone. This option is supported in PuppetDB >= 1.6.
 
+####`ssl_dir`
+
+Base directory for PuppetDB SSL configuration. Defaults to `/etc/puppetdb/ssl` or `/etc/puppetlabs/puppetdb/ssl` for FOSS and PE respectively.
+
+####`ssl_set_cert_paths`
+
+A switch to enable or disable the management of SSL certificates in your `jetty.ini` configuration file.
+
+####`ssl_cert_path`
+
+Path to your SSL certificate for populating `jetty.ini`.
+
+####`ssl_key_path`
+
+Path to your SSL key for populating `jetty.ini`.
+
+####`ssl_ca_cert_path`
+
+Path to your SSL CA for populating `jetty.ini`.
+
+####`ssl_deploy_certs`
+
+A boolean switch to enable or disable the management of SSL keys in your `ssl_dir`. Default is `false`.
+
+####`ssl_key`
+
+Contents of your SSL key, as a string.
+
+####`ssl_cert`
+
+Contents of your SSL certificate, as a string.
+
+####`ssl_ca_cert`
+
+Contents of your SSL CA certificate, as a string.
+
 
 ### puppetdb::server
 
 The `puppetdb::server` class manages the puppetdb server independently of the underlying database that it depends on. It will manage the puppetdb package, service, config files, etc., but will still allow you to manage the database (e.g. postgresql) however you see fit.
 
     class { 'puppetdb::server':
-      database_host => 'puppetdb-postgres',
+      database_host => 'pg1.mydomain.com',
     }
-
-**Parameters within `puppetdb::server`:**
-
-Uses the same parameters as `puppetdb`, with one addition:
-
-####`database_host`
-
-The hostname or IP address of the database server (defaults to `localhost`; ignored for `embedded` db).
 
 ### puppetdb::master::config
 
@@ -490,6 +522,10 @@ Sets the password for the database user above. Defaults to `puppetdb`.
 
 Conditionally manages the PostgresQL server via `postgresql::server`. Defaults to `true`. If set to false, this class will create the database and user via `postgresql::server::db` but not attempt to install or manage the server itself.
 
+####`test_url`
+
+The URL to use for testing if the PuppetDB instance is running. Defaults to `/v3/version`.
+
 Implementation
 ---------------
 
@@ -567,4 +603,4 @@ Puppet Labs modules on the Puppet Forge are open projects, and community contrib
 
 We want to keep it as easy as possible to contribute changes so that our modules work in your environment. There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things.
 
-You can read the complete module contribution guide [on the Puppet Labs wiki.](http://projects.puppetlabs.com/projects/module-site/wiki/Module_contributing)
+You can read the complete contribution guide [on the Puppet Labs documentation website](https://docs.puppetlabs.com/contribute.html)

--- a/lib/puppet/parser/functions/puppetdb_create_subsetting_resource_hash.rb
+++ b/lib/puppet/parser/functions/puppetdb_create_subsetting_resource_hash.rb
@@ -3,13 +3,13 @@ module Puppet::Parser::Functions
     java_args = args[0]
     params = args[1]
     resource_hash = {}
-    
+
     java_args.each { |k,v|
       item_params = { 'subsetting' => k, 'value' => (v || '') }
       item_params.merge!(params)
       resource_hash.merge!({ "'#{k}'" => item_params })
     }
-    
+
     resource_hash
   end
 end

--- a/lib/puppet/type/puppetdb_conn_validator.rb
+++ b/lib/puppet/type/puppetdb_conn_validator.rb
@@ -28,6 +28,10 @@ Puppet::Type.newtype(:puppetdb_conn_validator) do
     defaultto true
   end
 
+  newparam(:test_url) do
+    desc 'URL to use for testing if the PuppetDB database is up'
+  end
+
   newparam(:timeout) do
     desc 'The max number of seconds that the validator should wait before giving up and deciding that puppetdb is not running; defaults to 15 seconds.'
     defaultto 15

--- a/lib/puppet/util/puppetdb_validator.rb
+++ b/lib/puppet/util/puppetdb_validator.rb
@@ -2,45 +2,41 @@ require 'puppet/network/http_pool'
 
 module Puppet
   module Util
+    # Validator class, for testing that PuppetDB is alive
     class PuppetdbValidator
       attr_reader :puppetdb_server
       attr_reader :puppetdb_port
+      attr_reader :use_ssl
+      attr_reader :test_path
+      attr_reader :test_headers
 
-      def initialize(puppetdb_server, puppetdb_port, use_ssl=true)
+      def initialize(puppetdb_server, puppetdb_port, use_ssl=true, test_path = "/v3/version")
         @puppetdb_server = puppetdb_server
         @puppetdb_port   = puppetdb_port
         @use_ssl         = use_ssl
+        @test_path       = test_path
+        @test_headers    = { "Accept" => "application/json" }
       end
 
-      # Utility method; attempts to make an https connection to the puppetdb server.
+      # Utility method; attempts to make an http/https connection to the puppetdb server.
       # This is abstracted out into a method so that it can be called multiple times
       # for retry attempts.
       #
       # @return true if the connection is successful, false otherwise.
       def attempt_connection
         # All that we care about is that we are able to connect successfully via
-        # https, so here we're simpling hitting a somewhat arbitrary low-impact URL
+        # http(s), so here we're simpling hitting a somewhat arbitrary low-impact URL
         # on the puppetdb server.
-        path = "/v2/metrics/mbean/java.lang:type=Memory"
-        headers = {"Accept" => "application/json"}
-        if @use_ssl
-          conn = Puppet::Network::HttpPool.http_instance(@puppetdb_server, @puppetdb_port, @use_ssl)
-        else
-          # the Puppet httppool only supports disabling ssl in Puppet > 3.x
-          # this code allows ssl to be disabled for the connection on both 2.7 and 3.x
-          conn = Net::HTTP.new(@puppetdb_server, @puppetdb_port)
-          conn.read_timeout = Puppet[:configtimeout]
-          conn.open_timeout = Puppet[:configtimeout]
-        end
+        conn = Puppet::Network::HttpPool.http_instance(puppetdb_server, puppetdb_port, use_ssl)
 
-        response = conn.get(path, headers)
+        response = conn.get(test_path, test_headers)
         unless response.kind_of?(Net::HTTPSuccess)
-          Puppet.notice "Unable to connect to puppetdb server (#{@puppetdb_server}:#{@puppetdb_port}): [#{response.code}] #{response.msg}"
+          Puppet.notice "Unable to connect to puppetdb server (#{puppetdb_server}:#{puppetdb_port}): [#{response.code}] #{response.msg}"
           return false
         end
         return true
       rescue Exception => e
-        Puppet.notice "Unable to connect to puppetdb server (#{@puppetdb_server}:#{@puppetdb_port}): #{e.message}"
+        Puppet.notice "Unable to connect to puppetdb server (#{puppetdb_server}:#{puppetdb_port}): #{e.message}"
         return false
       end
     end

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -9,7 +9,7 @@ class puppetdb::database::postgresql(
 ) inherits puppetdb::params {
 
   if $manage_server == true {
-  # get the pg server up and running
+    # get the pg server up and running
     class { '::postgresql::server':
       ip_mask_allow_all_users => '0.0.0.0/0',
       listen_addresses        => $listen_addresses,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,6 @@
 # All in one class for setting up a PuppetDB instance. See README.md for more
 # details.
-class puppetdb(
+class puppetdb (
   $listen_address            = $puppetdb::params::listen_address,
   $listen_port               = $puppetdb::params::listen_port,
   $open_listen_port          = $puppetdb::params::open_listen_port,
@@ -8,8 +8,18 @@ class puppetdb(
   $ssl_listen_port           = $puppetdb::params::ssl_listen_port,
   $disable_ssl               = $puppetdb::params::disable_ssl,
   $open_ssl_listen_port      = $puppetdb::params::open_ssl_listen_port,
+  $ssl_dir                   = $puppetdb::params::ssl_dir,
+  $ssl_set_cert_paths        = $puppetdb::params::ssl_set_cert_paths,
+  $ssl_cert_path             = $puppetdb::params::ssl_cert_path,
+  $ssl_key_path              = $puppetdb::params::ssl_key_path,
+  $ssl_ca_cert_path          = $puppetdb::params::ssl_ca_cert_path,
+  $ssl_deploy_certs          = $puppetdb::params::ssl_deploy_certs,
+  $ssl_key                   = $puppetdb::params::ssl_key,
+  $ssl_cert                  = $puppetdb::params::ssl_cert,
+  $ssl_ca_cert               = $puppetdb::params::ssl_ca_cert,
   $manage_dbserver           = $puppetdb::params::manage_dbserver,
   $database                  = $puppetdb::params::database,
+  $database_host             = $puppetdb::params::database_host,
   $database_port             = $puppetdb::params::database_port,
   $database_username         = $puppetdb::params::database_username,
   $database_password         = $puppetdb::params::database_password,
@@ -28,6 +38,8 @@ class puppetdb(
   $puppetdb_version          = $puppetdb::params::puppetdb_version,
   $puppetdb_service          = $puppetdb::params::puppetdb_service,
   $puppetdb_service_status   = $puppetdb::params::puppetdb_service_status,
+  $puppetdb_user             = $puppetdb::params::puppetdb_user,
+  $puppetdb_group            = $puppetdb::params::puppetdb_group,
   $read_database             = $puppetdb::params::read_database,
   $read_database_host        = $puppetdb::params::read_database_host,
   $read_database_port        = $puppetdb::params::read_database_port,
@@ -40,44 +52,10 @@ class puppetdb(
   $read_conn_keep_alive      = $puppetdb::params::read_conn_keep_alive,
   $read_conn_lifetime        = $puppetdb::params::read_conn_lifetime,
   $confdir                   = $puppetdb::params::confdir,
-  $java_args                 = {},
-  $max_threads               = $puppetdb::params::max_threads
+  $manage_firewall           = $puppetdb::params::manage_firewall,
+  $java_args                 = $puppetdb::params::java_args,
+  $max_threads               = $puppetdb::params::max_threads,
 ) inherits puppetdb::params {
-
-  # Apply necessary suffix if zero is specified.
-  if $node_ttl == '0' {
-    $node_ttl_real = '0s'
-  } else {
-    $node_ttl_real = downcase($node_ttl)
-  }
-
-  # Validate node_ttl
-  validate_re ($node_ttl_real, ['^\d+(d|h|m|s|ms)$'], "node_ttl is <${node_ttl}> which does not match the regex validation")
-
-  # Apply necessary suffix if zero is specified.
-  if $node_purge_ttl == '0' {
-    $node_purge_ttl_real = '0s'
-  } else {
-    $node_purge_ttl_real = downcase($node_purge_ttl)
-  }
-
-  # Validate node_purge_ttl
-  validate_re ($node_purge_ttl_real, ['^\d+(d|h|m|s|ms)$'], "node_purge_ttl is <${node_purge_ttl}> which does not match the regex validation")
-
-  # Apply necessary suffix if zero is specified.
-  if $report_ttl == '0' {
-    $report_ttl_real = '0s'
-  } else {
-    $report_ttl_real = downcase($report_ttl)
-  }
-
-  # Validate report_ttl
-  validate_re ($report_ttl_real, ['^\d+(d|h|m|s|ms)$'], "report_ttl is <${report_ttl}> which does not match the regex validation")
-
-  # Validate puppetdb_service_status
-  if !($puppetdb_service_status in ['true', 'running', 'false', 'stopped']) {
-    fail("puppetdb_service_status valid values are 'true', 'running', 'false', and 'stopped'. You provided '${puppetdb_service_status}'")
-  }
 
   class { 'puppetdb::server':
     listen_address           => $listen_address,
@@ -87,7 +65,17 @@ class puppetdb(
     ssl_listen_port          => $ssl_listen_port,
     disable_ssl              => $disable_ssl,
     open_ssl_listen_port     => $open_ssl_listen_port,
+    ssl_dir                  => $ssl_dir,
+    ssl_set_cert_paths       => $ssl_set_cert_paths,
+    ssl_cert_path            => $ssl_cert_path,
+    ssl_key_path             => $ssl_key_path,
+    ssl_ca_cert_path         => $ssl_ca_cert_path,
+    ssl_deploy_certs         => $ssl_deploy_certs,
+    ssl_key                  => $ssl_key,
+    ssl_cert                 => $ssl_cert,
+    ssl_ca_cert              => $ssl_ca_cert,
     database                 => $database,
+    database_host            => $database_host,
     database_port            => $database_port,
     database_username        => $database_username,
     database_password        => $database_password,
@@ -119,6 +107,8 @@ class puppetdb(
     read_conn_max_age        => $read_conn_max_age,
     read_conn_keep_alive     => $read_conn_keep_alive,
     read_conn_lifetime       => $read_conn_lifetime,
+    puppetdb_user            => $puppetdb_user,
+    puppetdb_group           => $puppetdb_group,
   }
 
   if ($database == 'postgres') {
@@ -128,7 +118,7 @@ class puppetdb(
       database_username => $database_username,
       database_password => $database_password,
       manage_server     => $manage_dbserver,
-      before            => [Class['puppetdb::server'],Class['puppetdb::server::validate_db']],
+      before            => [Class['puppetdb::server'], Class['puppetdb::server::validate_db']],
     }
   }
 }

--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -1,8 +1,11 @@
 # Manage puppet configuration. See README.md for more details.
-class puppetdb::master::config(
+class puppetdb::master::config (
   $puppetdb_server             = $::fqdn,
   $puppetdb_port               = defined('$puppetdb::disable_ssl') ? {
-    true    => $puppetdb::disable_ssl ? { true => 8080, default => 8081, },
+    true    => $puppetdb::disable_ssl ? {
+      true => 8080,
+      default => 8081,
+    },
     default => 8081,
   },
   $puppetdb_soft_write_failure = false,
@@ -18,7 +21,8 @@ class puppetdb::master::config(
   $terminus_package            = $puppetdb::params::terminus_package,
   $puppet_service_name         = $puppetdb::params::puppet_service_name,
   $puppetdb_startup_timeout    = $puppetdb::params::puppetdb_startup_timeout,
-  $restart_puppet              = true
+  $test_url                    = $puppetdb::params::test_url,
+  $restart_puppet              = true,
 ) inherits puppetdb::params {
 
   package { $terminus_package:
@@ -43,6 +47,7 @@ class puppetdb::master::config(
       },
       timeout         => $puppetdb_startup_timeout,
       require         => Package[$terminus_package],
+      test_url        => $test_url,
     }
 
     # This is a bit of puppet chicanery that allows us to create a

--- a/manifests/master/puppetdb_conf.pp
+++ b/manifests/master/puppetdb_conf.pp
@@ -1,9 +1,12 @@
-# Managed the puppetdb.conf file on the puppeet master. See README.md for more
+# Manage the puppetdb.conf file on the puppeet master. See README.md for more
 # details.
 class puppetdb::master::puppetdb_conf (
   $server             = 'localhost',
   $port               = '8081',
-  $soft_write_failure = $puppetdb::disable_ssl ? { true => true, default => false, },
+  $soft_write_failure = $puppetdb::disable_ssl ? {
+    true => true,
+    default => false,
+  },
   $puppet_confdir     = $puppetdb::params::puppet_confdir,
 ) inherits puppetdb::params {
 

--- a/manifests/master/report_processor.pp
+++ b/manifests/master/report_processor.pp
@@ -1,6 +1,6 @@
-# Manages the installation of the report processor on the master. See README.md
+# Manage the installation of the report processor on the master. See README.md
 # for more details.
-class puppetdb::master::report_processor(
+class puppetdb::master::report_processor (
   $puppet_conf = $puppetdb::params::puppet_conf,
   $enable      = false
 ) inherits puppetdb::params {
@@ -13,6 +13,6 @@ class puppetdb::master::report_processor(
     section              => 'master',
     setting              => 'reports',
     subsetting           => 'puppetdb',
-    subsetting_separator => ','
+    subsetting_separator => ',',
   }
 }

--- a/manifests/master/routes.pp
+++ b/manifests/master/routes.pp
@@ -1,6 +1,6 @@
 # Manages the routes configuration file on the master. See README.md for more
 # details.
-class puppetdb::master::routes(
+class puppetdb::master::routes (
   $puppet_confdir = $puppetdb::params::puppet_confdir,
   $routes = {
     'master' => {

--- a/manifests/master/storeconfigs.pp
+++ b/manifests/master/storeconfigs.pp
@@ -1,10 +1,10 @@
 # This class configures the puppet master to enable storeconfigs and to use
 # puppetdb as the storeconfigs backend. See README.md for more details.
-class puppetdb::master::storeconfigs(
-  $puppet_conf = $puppetdb::params::puppet_conf
+class puppetdb::master::storeconfigs (
+  $puppet_conf = $puppetdb::params::puppet_conf,
 ) inherits puppetdb::params {
 
-  Ini_setting{
+  Ini_setting {
     section => 'master',
     path    => $puppet_conf,
     ensure  => present,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,3 +1,5 @@
+# PRIVATE CLASS - do not use directly
+#
 # The puppetdb default configuration settings.
 class puppetdb::params {
   $listen_address            = 'localhost'
@@ -7,15 +9,6 @@ class puppetdb::params {
   $ssl_listen_port           = '8081'
   $disable_ssl               = false
   $open_ssl_listen_port      = undef
-  $ssl_dir                   = '/etc/puppetdb/ssl'
-  $ssl_set_cert_paths        = false
-  $ssl_cert_path             = "${ssl_dir}/public.pem"
-  $ssl_key_path              = "${ssl_dir}/private.pem"
-  $ssl_ca_cert_path          = "${ssl_dir}/ca.pem"
-  $ssl_deploy_certs          = false
-  $ssl_key                   = undef
-  $ssl_cert                  = undef
-  $ssl_ca_cert               = undef
   $postgres_listen_addresses = 'localhost'
 
   $database                  = 'postgres'
@@ -58,6 +51,10 @@ class puppetdb::params {
   $read_conn_keep_alive     = '45'
   $read_conn_lifetime       = '0'
 
+  $manage_firewall = true
+  $java_args       = {}
+  $test_url        = '/v3/version'
+
   case $::osfamily {
     'RedHat': {
       $firewall_supported       = true
@@ -84,6 +81,7 @@ class puppetdb::params {
     $puppet_confdir       = '/etc/puppetlabs/puppet'
     $terminus_package     = 'pe-puppetdb-terminus'
     $embedded_subname     = 'file:/opt/puppet/share/puppetdb/db/db;hsqldb.tx=mvcc;sql.syntax_pgs=true'
+    $ssl_dir              = '/etc/puppetlabs/puppetdb/ssl'
 
     case $::osfamily {
       'RedHat', 'Suse': {
@@ -104,6 +102,7 @@ class puppetdb::params {
     $confdir              = '/etc/puppetdb/conf.d'
     $puppet_confdir       = '/etc/puppet'
     $terminus_package     = 'puppetdb-terminus'
+    $ssl_dir              = '/etc/puppetdb/ssl'
 
     case $::osfamily {
       'RedHat', 'Suse', 'Archlinux': {
@@ -130,4 +129,13 @@ class puppetdb::params {
   $puppet_conf              = "${puppet_confdir}/puppet.conf"
   $puppetdb_startup_timeout = 120
   $puppetdb_service_status  = 'running'
+
+  $ssl_set_cert_paths        = false
+  $ssl_cert_path             = "${ssl_dir}/public.pem"
+  $ssl_key_path              = "${ssl_dir}/private.pem"
+  $ssl_ca_cert_path          = "${ssl_dir}/ca.pem"
+  $ssl_deploy_certs          = false
+  $ssl_key                   = undef
+  $ssl_cert                  = undef
+  $ssl_ca_cert               = undef
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,57 +1,57 @@
 # Class to configure a PuppetDB server. See README.md for more details.
-class puppetdb::server(
-  $listen_address          = $puppetdb::params::listen_address,
-  $listen_port             = $puppetdb::params::listen_port,
-  $open_listen_port        = $puppetdb::params::open_listen_port,
-  $ssl_listen_address      = $puppetdb::params::ssl_listen_address,
-  $ssl_listen_port         = $puppetdb::params::ssl_listen_port,
-  $disable_ssl             = $puppetdb::params::disable_ssl,
-  $open_ssl_listen_port    = $puppetdb::params::open_ssl_listen_port,
-  $ssl_dir                 = $puppetdb::params::ssl_dir,
-  $ssl_set_cert_paths      = $puppetdb::params::ssl_set_cert_paths,
-  $ssl_cert_path           = $puppetdb::params::ssl_cert_path,
-  $ssl_key_path            = $puppetdb::params::ssl_key_path,
-  $ssl_ca_cert_path        = $puppetdb::params::ssl_ca_cert_path,
-  $ssl_deploy_certs        = $puppetdb::params::ssl_deploy_certs,
-  $ssl_key                 = $puppetdb::params::ssl_key,
-  $ssl_cert                = $puppetdb::params::ssl_cert,
-  $ssl_ca_cert             = $puppetdb::params::ssl_ca_cert,
-  $database                = $puppetdb::params::database,
-  $database_host           = $puppetdb::params::database_host,
-  $database_port           = $puppetdb::params::database_port,
-  $database_username       = $puppetdb::params::database_username,
-  $database_password       = $puppetdb::params::database_password,
-  $database_name           = $puppetdb::params::database_name,
-  $database_ssl            = $puppetdb::params::database_ssl,
-  $node_ttl                = $puppetdb::params::node_ttl,
-  $node_purge_ttl          = $puppetdb::params::node_purge_ttl,
-  $report_ttl              = $puppetdb::params::report_ttl,
-  $gc_interval             = $puppetdb::params::gc_interval,
-  $log_slow_statements     = $puppetdb::params::log_slow_statements,
-  $conn_max_age            = $puppetdb::params::conn_max_age,
-  $conn_keep_alive         = $puppetdb::params::conn_keep_alive,
-  $conn_lifetime           = $puppetdb::params::conn_lifetime,
-  $read_database           = $puppetdb::params::read_database,
-  $read_database_host      = $puppetdb::params::read_database_host,
-  $read_database_port      = $puppetdb::params::read_database_port,
-  $read_database_username  = $puppetdb::params::read_database_username,
-  $read_database_password  = $puppetdb::params::read_database_password,
-  $read_database_name      = $puppetdb::params::read_database_name,
-  $read_database_ssl       = $puppetdb::params::read_database_ssl,
+class puppetdb::server (
+  $listen_address           = $puppetdb::params::listen_address,
+  $listen_port              = $puppetdb::params::listen_port,
+  $open_listen_port         = $puppetdb::params::open_listen_port,
+  $ssl_listen_address       = $puppetdb::params::ssl_listen_address,
+  $ssl_listen_port          = $puppetdb::params::ssl_listen_port,
+  $disable_ssl              = $puppetdb::params::disable_ssl,
+  $open_ssl_listen_port     = $puppetdb::params::open_ssl_listen_port,
+  $ssl_dir                  = $puppetdb::params::ssl_dir,
+  $ssl_set_cert_paths       = $puppetdb::params::ssl_set_cert_paths,
+  $ssl_cert_path            = $puppetdb::params::ssl_cert_path,
+  $ssl_key_path             = $puppetdb::params::ssl_key_path,
+  $ssl_ca_cert_path         = $puppetdb::params::ssl_ca_cert_path,
+  $ssl_deploy_certs         = $puppetdb::params::ssl_deploy_certs,
+  $ssl_key                  = $puppetdb::params::ssl_key,
+  $ssl_cert                 = $puppetdb::params::ssl_cert,
+  $ssl_ca_cert              = $puppetdb::params::ssl_ca_cert,
+  $database                 = $puppetdb::params::database,
+  $database_host            = $puppetdb::params::database_host,
+  $database_port            = $puppetdb::params::database_port,
+  $database_username        = $puppetdb::params::database_username,
+  $database_password        = $puppetdb::params::database_password,
+  $database_name            = $puppetdb::params::database_name,
+  $database_ssl             = $puppetdb::params::database_ssl,
+  $node_ttl                 = $puppetdb::params::node_ttl,
+  $node_purge_ttl           = $puppetdb::params::node_purge_ttl,
+  $report_ttl               = $puppetdb::params::report_ttl,
+  $gc_interval              = $puppetdb::params::gc_interval,
+  $log_slow_statements      = $puppetdb::params::log_slow_statements,
+  $conn_max_age             = $puppetdb::params::conn_max_age,
+  $conn_keep_alive          = $puppetdb::params::conn_keep_alive,
+  $conn_lifetime            = $puppetdb::params::conn_lifetime,
+  $puppetdb_package         = $puppetdb::params::puppetdb_package,
+  $puppetdb_version         = $puppetdb::params::puppetdb_version,
+  $puppetdb_service         = $puppetdb::params::puppetdb_service,
+  $puppetdb_service_status  = $puppetdb::params::puppetdb_service_status,
+  $puppetdb_user            = $puppetdb::params::puppetdb_user,
+  $puppetdb_group           = $puppetdb::params::puppetdb_group,
+  $read_database            = $puppetdb::params::read_database,
+  $read_database_host       = $puppetdb::params::read_database_host,
+  $read_database_port       = $puppetdb::params::read_database_port,
+  $read_database_username   = $puppetdb::params::read_database_username,
+  $read_database_password   = $puppetdb::params::read_database_password,
+  $read_database_name       = $puppetdb::params::read_database_name,
+  $read_database_ssl        = $puppetdb::params::read_database_ssl,
   $read_log_slow_statements = $puppetdb::params::read_log_slow_statements,
-  $read_conn_max_age       = $puppetdb::params::read_conn_max_age,
-  $read_conn_keep_alive    = $puppetdb::params::read_conn_keep_alive,
-  $read_conn_lifetime      = $puppetdb::params::read_conn_lifetime,
-  $puppetdb_package        = $puppetdb::params::puppetdb_package,
-  $puppetdb_version        = $puppetdb::params::puppetdb_version,
-  $puppetdb_service        = $puppetdb::params::puppetdb_service,
-  $puppetdb_user           = $puppetdb::params::puppetdb_user,
-  $puppetdb_group          = $puppetdb::params::puppetdb_group,
-  $puppetdb_service_status = $puppetdb::params::puppetdb_service_status,
-  $confdir                 = $puppetdb::params::confdir,
-  $manage_firewall         = true,
-  $java_args               = {},
-  $max_threads             = $puppetdb::params::max_threads
+  $read_conn_max_age        = $puppetdb::params::read_conn_max_age,
+  $read_conn_keep_alive     = $puppetdb::params::read_conn_keep_alive,
+  $read_conn_lifetime       = $puppetdb::params::read_conn_lifetime,
+  $confdir                  = $puppetdb::params::confdir,
+  $manage_firewall          = $puppetdb::params::manage_firewall,
+  $java_args                = $puppetdb::params::java_args,
+  $max_threads              = $puppetdb::params::max_threads,
 ) inherits puppetdb::params {
 
   # Apply necessary suffix if zero is specified.
@@ -87,6 +87,11 @@ class puppetdb::server(
   # Validate puppetdb_service_status
   if !($puppetdb_service_status in ['true', 'running', 'false', 'stopped']) {
     fail("puppetdb_service_status valid values are 'true', 'running', 'false', and 'stopped'. You provided '${puppetdb_service_status}'")
+  }
+
+  # Validate read-database type (Currently only postgres is supported)
+  if !($database in ['postgres', 'embedded']) {
+    fail("database must must be 'postgres' or 'embedded'. You provided '${database}'")
   }
 
   # Validate read-database type (Currently only postgres is supported)
@@ -154,7 +159,7 @@ class puppetdb::server(
     validate_absolute_path($ssl_dir)
     file{
       $ssl_dir:
-        ensure => directory,
+        ensure  => directory,
         owner   => $puppetdb_user,
         group   => $puppetdb_group,
         mode    => '0700';
@@ -195,7 +200,6 @@ class puppetdb::server(
   }
 
   if !empty($java_args) {
-
     create_resources(
       'ini_subsetting',
       puppetdb_create_subsetting_resource_hash(

--- a/manifests/server/database_ini.pp
+++ b/manifests/server/database_ini.pp
@@ -1,5 +1,5 @@
 # PRIVATE CLASS - do not use directly
-class puppetdb::server::database_ini(
+class puppetdb::server::database_ini (
   $database          = $puppetdb::params::database,
   $database_host     = $puppetdb::params::database_host,
   $database_port     = $puppetdb::params::database_port,
@@ -35,7 +35,7 @@ class puppetdb::server::database_ini(
     database_name     => $database_name,
   }
 
-  #Set the defaults
+  # Set the defaults
   Ini_setting {
     path    => "${confdir}/database.ini",
     ensure  => present,
@@ -43,7 +43,7 @@ class puppetdb::server::database_ini(
     require => Class['puppetdb::server::validate_db'],
   }
 
-  if $database == 'embedded'{
+  if $database == 'embedded' {
 
     $classname   = 'org.hsqldb.jdbcDriver'
     $subprotocol = 'hsqldb'
@@ -72,62 +72,62 @@ class puppetdb::server::database_ini(
     }
   }
 
-  ini_setting {'puppetdb_classname':
+  ini_setting { 'puppetdb_classname':
     setting => 'classname',
     value   => $classname,
   }
 
-  ini_setting {'puppetdb_subprotocol':
+  ini_setting { 'puppetdb_subprotocol':
     setting => 'subprotocol',
     value   => $subprotocol,
   }
 
-  ini_setting {'puppetdb_pgs':
+  ini_setting { 'puppetdb_pgs':
     setting => 'syntax_pgs',
     value   => true,
   }
 
-  ini_setting {'puppetdb_subname':
+  ini_setting { 'puppetdb_subname':
     setting => 'subname',
     value   => $subname,
   }
 
-  ini_setting {'puppetdb_gc_interval':
+  ini_setting { 'puppetdb_gc_interval':
     setting => 'gc-interval',
     value   => $gc_interval,
   }
 
-  ini_setting {'puppetdb_node_ttl':
+  ini_setting { 'puppetdb_node_ttl':
     setting => 'node-ttl',
     value   => $node_ttl,
   }
 
-  ini_setting {'puppetdb_node_purge_ttl':
+  ini_setting { 'puppetdb_node_purge_ttl':
     setting => 'node-purge-ttl',
     value   => $node_purge_ttl,
   }
 
-  ini_setting {'puppetdb_report_ttl':
+  ini_setting { 'puppetdb_report_ttl':
     setting => 'report-ttl',
     value   => $report_ttl,
   }
 
-  ini_setting {'puppetdb_log_slow_statements':
+  ini_setting { 'puppetdb_log_slow_statements':
     setting => 'log-slow-statements',
     value   => $log_slow_statements,
   }
 
-  ini_setting {'puppetdb_conn_max_age':
+  ini_setting { 'puppetdb_conn_max_age':
     setting => 'conn-max-age',
     value   => $conn_max_age,
   }
 
-  ini_setting {'puppetdb_conn_keep_alive':
+  ini_setting { 'puppetdb_conn_keep_alive':
     setting => 'conn-keep-alive',
     value   => $conn_keep_alive,
   }
 
-  ini_setting {'puppetdb_conn_lifetime':
+  ini_setting { 'puppetdb_conn_lifetime':
     setting => 'conn-lifetime',
     value   => $conn_lifetime,
   }

--- a/manifests/server/firewall.pp
+++ b/manifests/server/firewall.pp
@@ -1,5 +1,5 @@
 # PRIVATE CLASS - do not use directly
-class puppetdb::server::firewall(
+class puppetdb::server::firewall (
   $http_port      = $puppetdb::params::listen_port,
   $open_http_port = $puppetdb::params::open_listen_port,
   $ssl_port       = $puppetdb::params::ssl_listen_port,

--- a/manifests/server/jetty_ini.pp
+++ b/manifests/server/jetty_ini.pp
@@ -1,5 +1,5 @@
 # PRIVATE CLASS - do not use directly
-class puppetdb::server::jetty_ini(
+class puppetdb::server::jetty_ini (
   $listen_address     = $puppetdb::params::listen_address,
   $listen_port        = $puppetdb::params::listen_port,
   $ssl_listen_address = $puppetdb::params::ssl_listen_address,
@@ -13,22 +13,19 @@ class puppetdb::server::jetty_ini(
   $max_threads        = $puppetdb::params::max_threads,
 ) inherits puppetdb::params {
 
-  #Set the defaults
+  # Set the defaults
   Ini_setting {
     path    => "${confdir}/jetty.ini",
     ensure  => present,
     section => 'jetty',
   }
 
-  # TODO: figure out some way to make sure that the inifile module is installed,
-  #  because otherwise these will silently fail to do anything.
-
-  ini_setting {'puppetdb_host':
+  ini_setting { 'puppetdb_host':
     setting => 'host',
     value   => $listen_address,
   }
 
-  ini_setting {'puppetdb_port':
+  ini_setting { 'puppetdb_port':
     setting => 'port',
     value   => $listen_port,
   }
@@ -38,44 +35,44 @@ class puppetdb::server::jetty_ini(
     default => 'present',
   }
 
+  ini_setting { 'puppetdb_sslhost':
+    ensure  => $ssl_setting_ensure,
+    setting => 'ssl-host',
+    value   => $ssl_listen_address,
+  }
+
+  ini_setting { 'puppetdb_sslport':
+    ensure  => $ssl_setting_ensure,
+    setting => 'ssl-port',
+    value   => $ssl_listen_port,
+  }
+
   if str2bool($ssl_set_cert_paths) == true {
     # assume paths have been validated in calling class
-    ini_setting {'puppetdb_ssl_key':
+    ini_setting { 'puppetdb_ssl_key':
       ensure  => present,
       setting => 'ssl-key',
       value   => $ssl_key_path,
     }
-    ini_setting {'puppetdb_ssl_cert':
+    ini_setting { 'puppetdb_ssl_cert':
       ensure  => present,
       setting => 'ssl-cert',
       value   => $ssl_cert_path,
     }
-    ini_setting {'puppetdb_ssl_ca_cert':
+    ini_setting { 'puppetdb_ssl_ca_cert':
       ensure  => present,
       setting => 'ssl-ca-cert',
       value   => $ssl_ca_cert_path,
     }
   }
 
-  ini_setting {'puppetdb_sslhost':
-    ensure  => $ssl_setting_ensure,
-    setting => 'ssl-host',
-    value   => $ssl_listen_address,
-  }
-
-  ini_setting {'puppetdb_sslport':
-    ensure  => $ssl_setting_ensure,
-    setting => 'ssl-port',
-    value   => $ssl_listen_port,
-  }
-
   if ($max_threads) {
-    ini_setting {'puppetdb_max_threads':
+    ini_setting { 'puppetdb_max_threads':
       setting => 'max-threads',
       value   => $max_threads,
     }
   } else {
-    ini_setting {'puppetdb_max_threads':
+    ini_setting { 'puppetdb_max_threads':
       ensure  => absent,
       setting => 'max-threads',
     }

--- a/manifests/server/read_database_ini.pp
+++ b/manifests/server/read_database_ini.pp
@@ -1,5 +1,5 @@
 # PRIVATE CLASS - do not use directly
-class puppetdb::server::read_database_ini(
+class puppetdb::server::read_database_ini (
   $database            = $puppetdb::params::read_database,
   $database_host       = $puppetdb::params::read_database_host,
   $database_port       = $puppetdb::params::read_database_port,
@@ -42,7 +42,7 @@ class puppetdb::server::read_database_ini(
       mode   => '0600';
     }
 
-    #Set the defaults
+    # Set the defaults
     Ini_setting {
       path    => "${confdir}/read_database.ini",
       ensure  => present,
@@ -59,55 +59,55 @@ class puppetdb::server::read_database_ini(
         default => "//${database_host}:${database_port}/${database_name}",
       }
 
-      ini_setting {'puppetdb_read_psdatabase_username':
+      ini_setting { 'puppetdb_read_psdatabase_username':
         setting => 'username',
         value   => $database_username,
       }
 
       if $database_password != undef {
-        ini_setting {'puppetdb_read_psdatabase_password':
+        ini_setting { 'puppetdb_read_psdatabase_password':
           setting => 'password',
           value   => $database_password,
         }
       }
     }
 
-    ini_setting {'puppetdb_read_classname':
+    ini_setting { 'puppetdb_read_classname':
       setting => 'classname',
       value   => $classname,
     }
 
-    ini_setting {'puppetdb_read_subprotocol':
+    ini_setting { 'puppetdb_read_subprotocol':
       setting => 'subprotocol',
       value   => $subprotocol,
     }
 
-    ini_setting {'puppetdb_read_pgs':
+    ini_setting { 'puppetdb_read_pgs':
       setting => 'syntax_pgs',
       value   => true,
     }
 
-    ini_setting {'puppetdb_read_subname':
+    ini_setting { 'puppetdb_read_subname':
       setting => 'subname',
       value   => $subname,
     }
 
-    ini_setting {'puppetdb_read_log_slow_statements':
+    ini_setting { 'puppetdb_read_log_slow_statements':
       setting => 'log-slow-statements',
       value   => $log_slow_statements,
     }
 
-    ini_setting {'puppetdb_read_conn_max_age':
+    ini_setting { 'puppetdb_read_conn_max_age':
       setting => 'conn-max-age',
       value   => $conn_max_age,
     }
 
-    ini_setting {'puppetdb_read_conn_keep_alive':
+    ini_setting { 'puppetdb_read_conn_keep_alive':
       setting => 'conn-keep-alive',
       value   => $conn_keep_alive,
     }
 
-    ini_setting {'puppetdb_read_conn_lifetime':
+    ini_setting { 'puppetdb_read_conn_lifetime':
       setting => 'conn-lifetime',
       value   => $conn_lifetime,
     }

--- a/manifests/server/validate_db.pp
+++ b/manifests/server/validate_db.pp
@@ -1,17 +1,18 @@
 # This validates a database connection. See README.md for more details.
-class puppetdb::server::validate_db(
+class puppetdb::server::validate_db (
   $database          = $puppetdb::params::database,
   $database_host     = $puppetdb::params::database_host,
   $database_port     = $puppetdb::params::database_port,
   $database_username = $puppetdb::params::database_username,
   $database_password = $puppetdb::params::database_password,
   $database_name     = $puppetdb::params::database_name,
-  $database_ssl      = $puppetdb::params::database_ssl
+  $database_ssl      = $puppetdb::params::database_ssl,
 ) inherits puppetdb::params {
 
   # We don't need any validation for the embedded database, presumably.
-  if ($database == 'postgres' and (
-    $database_password != undef and $database_ssl == false)
+  if (
+    $database == 'postgres' and
+    ($database_password != undef and $database_ssl == false)
   ) {
     postgresql::validate_db_connection { 'validate puppetdb postgres connection':
       database_host     => $database_host,

--- a/manifests/server/validate_read_db.pp
+++ b/manifests/server/validate_read_db.pp
@@ -1,17 +1,18 @@
 # This validates a database connection. See README.md for more details.
-class puppetdb::server::validate_read_db(
+class puppetdb::server::validate_read_db (
   $database          = $puppetdb::params::database,
   $database_host     = $puppetdb::params::database_host,
   $database_port     = $puppetdb::params::database_port,
   $database_username = $puppetdb::params::database_username,
   $database_password = $puppetdb::params::database_password,
   $database_name     = $puppetdb::params::database_name,
-  $database_ssl      = $puppetdb::params::database_ssl
+  $database_ssl      = $puppetdb::params::database_ssl,
 ) inherits puppetdb::params {
 
   # Currently we only support postgres
-  if ($database == 'postgres' and (
-    $database_password != undef and $database_ssl == false)
+  if (
+    $database == 'postgres' and
+    ($database_password != undef and $database_ssl == false)
   ) {
     postgresql::validate_db_connection { 'validate puppetdb postgres (read) connection':
       database_host     => $database_host,

--- a/spec/unit/util/puppetdb_validator_spec.rb
+++ b/spec/unit/util/puppetdb_validator_spec.rb
@@ -12,29 +12,29 @@ describe 'Puppet::Util::PuppetdbValidator' do
     response_not_found.stubs(:msg).returns('Not found')
 
     conn_ok = stub()
-    conn_ok.stubs(:get).with('/v2/metrics/mbean/java.lang:type=Memory', {"Accept" => "application/json"}).returns(response_ok)
+    conn_ok.stubs(:get).with('/v3/version', {"Accept" => "application/json"}).returns(response_ok)
     conn_ok.stubs(:read_timeout=).with(2)
     conn_ok.stubs(:open_timeout=).with(2)
 
     conn_not_found = stub()
-    conn_not_found.stubs(:get).with('/v2/metrics/mbean/java.lang:type=Memory', {"Accept" => "application/json"}).returns(response_not_found)
+    conn_not_found.stubs(:get).with('/v3/version', {"Accept" => "application/json"}).returns(response_not_found)
 
     Puppet::Network::HttpPool.stubs(:http_instance).raises('Unknown host')
     Puppet::Network::HttpPool.stubs(:http_instance).with('mypuppetdb.com', 8080, true).raises('Connection refused')
+    Puppet::Network::HttpPool.stubs(:http_instance).with('mypuppetdb.com', 8080, false).returns(conn_ok)
     Puppet::Network::HttpPool.stubs(:http_instance).with('mypuppetdb.com', 8081, true).returns(conn_ok)
     Puppet::Network::HttpPool.stubs(:http_instance).with('wrongserver.com', 8081, true).returns(conn_not_found)
-    Net::HTTP.stubs(:new).with('mypuppetdb.com', 8080).returns(conn_ok)
   end
 
   it 'returns true if connection succeeds' do
     validator = Puppet::Util::PuppetdbValidator.new('mypuppetdb.com', 8081)
-    validator.attempt_connection.should be_true
+    validator.attempt_connection.should be true
   end
 
   it 'should still validate without ssl' do
     Puppet[:configtimeout] = 2
     validator = Puppet::Util::PuppetdbValidator.new('mypuppetdb.com', 8080, false)
-    validator.attempt_connection.should be_true
+    validator.attempt_connection.should be true
   end
 
   it 'returns false and issues an appropriate notice if connection is refused' do
@@ -42,8 +42,7 @@ describe 'Puppet::Util::PuppetdbValidator' do
     puppetdb_port = 8080
     validator = Puppet::Util::PuppetdbValidator.new(puppetdb_server, puppetdb_port)
     Puppet.expects(:notice).with("Unable to connect to puppetdb server (#{puppetdb_server}:#{puppetdb_port}): Connection refused")
-    #Puppet.expects(:notice).with("Unable to connect to puppetdb server (#{puppetdb_server}:#{puppetdb_port}): [404] Not found")
-    validator.attempt_connection.should be_false    
+    validator.attempt_connection.should be false
   end
 
   it 'returns false and issues an appropriate notice if connection succeeds but puppetdb is not available' do
@@ -51,17 +50,15 @@ describe 'Puppet::Util::PuppetdbValidator' do
     puppetdb_port = 8081
     validator = Puppet::Util::PuppetdbValidator.new(puppetdb_server, puppetdb_port)
     Puppet.expects(:notice).with("Unable to connect to puppetdb server (#{puppetdb_server}:#{puppetdb_port}): [404] Not found")
-    validator.attempt_connection.should be_false    
+    validator.attempt_connection.should be false
   end
-
 
   it 'returns false and issues an appropriate notice if host:port is unreachable or does not exist' do
     puppetdb_server = 'non-existing.com'
     puppetdb_port = nil
     validator = Puppet::Util::PuppetdbValidator.new(puppetdb_server, puppetdb_port)
     Puppet.expects(:notice).with("Unable to connect to puppetdb server (#{puppetdb_server}:#{puppetdb_port}): Unknown host")
-    validator.attempt_connection.should be_false    
+    validator.attempt_connection.should be false
   end
-
 
 end


### PR DESCRIPTION
This provides a number of cleanups as the code has been unloved for a while.

I've added the ssl-\* parameters the robinbowes added in his last patch to the
docs, and found some other cleanups as well where applicable.

I've added the ability to override the test_url also, so that in the future
if a user wishes to they can customize this.

Signed-off-by: Ken Barber ken@bob.sh
