### PR TITLE
Remove invisible unicode character to prevent "invalid byte sequence in ...

### DIFF
--- a/manifests/server/jetty_ini.pp
+++ b/manifests/server/jetty_ini.pp
@@ -48,7 +48,7 @@ class puppetdb::server::jetty_ini (
   }
 
   if str2bool($ssl_set_cert_paths) == true {
-    # assume paths have been validated in calling class
+    # assume paths have been validated in calling class
     ini_setting { 'puppetdb_ssl_key':
       ensure  => present,
       setting => 'ssl-key',


### PR DESCRIPTION
Someone inserted an unicode character (probably by accident) to the jetty_ini.pp file which prevents puppet-run without unicode environment to run the puppet module.
Those scenarios are likely while bootstrapping new server.

The rest of the files looks good.

```
$ find . -name '*.pp' -exec file {} +
./manifests/master/config.pp:            ASCII English text
./manifests/master/routes.pp:            ASCII English text
./manifests/master/storeconfigs.pp:      ASCII English text
./manifests/master/puppetdb_conf.pp:     ASCII English text
./manifests/master/report_processor.pp:  ASCII English text
./manifests/server/validate_db.pp:       ASCII English text
./manifests/server/database_ini.pp:      ASCII English text
./manifests/server/jetty_ini.pp:         ASCII English text
./manifests/server/validate_read_db.pp:  ASCII text
./manifests/server/read_database_ini.pp: ASCII English text
./manifests/server/firewall.pp:          ASCII text
./manifests/init.pp:                     ASCII C++ program text
./manifests/params.pp:                   ASCII C++ program text
./manifests/server.pp:                   ASCII English text
./manifests/database/postgresql.pp:      ASCII C++ program text
```
