### PR TITLE
(maint) Correct path for hsqldb storage

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -109,12 +109,12 @@ class puppetdb::params {
       'RedHat', 'Suse', 'Archlinux': {
         $puppetdb_initconf    = '/etc/sysconfig/puppetdb'
         $puppet_service_name  = 'puppetmaster'
-        $embedded_subname     = 'file:/usr/share/puppetdb/db/db;hsqldb.tx=mvcc;sql.syntax_pgs=true'
+        $embedded_subname     = 'file:/var/lib/puppetdb/db/db;hsqldb.tx=mvcc;sql.syntax_pgs=true'
       }
       'Debian': {
         $puppetdb_initconf    = '/etc/default/puppetdb'
         $puppet_service_name  = 'puppetmaster'
-        $embedded_subname     = 'file:/usr/share/puppetdb/db/db;hsqldb.tx=mvcc;sql.syntax_pgs=true'
+        $embedded_subname     = 'file:/var/lib/puppetdb/db/db;hsqldb.tx=mvcc;sql.syntax_pgs=true'
       }
       'OpenBSD': {
         $puppetdb_initconf    = undef


### PR DESCRIPTION
For some reasons we switched this to use /usr/share/puppetdb/db, which has a
softlink to /var/lib/puppetdb/db. This is not aligned with the PuppetDB core
nor is it following FHS.

Signed-off-by: Ken Barber ken@bob.sh
