### PR TITLE
add missing param manage_firewall

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,10 @@ Contents of your SSL certificate, as a string.
 
 Contents of your SSL CA certificate, as a string.
 
+####`manage_firewall`
+
+if true, puppet will manage your iptables rules for puppetdb via the [puppetlabs-firewall](https://forge.puppetlabs.com/puppetlabs/firewall) class.
+
 
 ### puppetdb::server
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -109,6 +109,7 @@ class puppetdb (
     read_conn_lifetime       => $read_conn_lifetime,
     puppetdb_user            => $puppetdb_user,
     puppetdb_group           => $puppetdb_group,
+    manage_firewall          => $manage_firewall,
   }
 
   if ($database == 'postgres') {


### PR DESCRIPTION
the param manage_firewall was added in an earlier release to puppetdb::server. The class isn't called directly but via the init.pp. the puppetdb class had already the param manage_firewall but this wasn't forwarded to puppetdb::server