### PR TITLE
Fix separator in module name in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-    "name": "puppetlabs/puppetdb",
+    "name": "puppetlabs-puppetdb",
     "version": "4.1.0",
     "summary": "Installs PostgreSQL and PuppetDB, sets up the connection to Puppet master.",
     "source": "git://github.com/puppetlabs/puppetlabs-puppetdb.git",


### PR DESCRIPTION
Fix module name, using hyphen separator as documented at https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#another-note-on-module-names, rather than non-standard slash, which confuses some tools.

Version number will need to be bumped when this is published.

Relates to PDB-1115