### PR TITLE
(PDB-1035) Set terminus package-name dynamically

### DIFF
--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -22,12 +22,19 @@ class puppetdb::master::config (
   $puppet_confdir              = $puppetdb::params::puppet_confdir,
   $puppet_conf                 = $puppetdb::params::puppet_conf,
   $puppetdb_version            = $puppetdb::params::puppetdb_version,
-  $terminus_package            = $puppetdb::params::terminus_package,
   $puppet_service_name         = $puppetdb::params::puppet_service_name,
   $puppetdb_startup_timeout    = $puppetdb::params::puppetdb_startup_timeout,
   $test_url                    = $puppetdb::params::test_url,
   $restart_puppet              = true,
 ) inherits puppetdb::params {
+
+  $terminus_package = $puppetdb_version ? {
+    'latest', 'present', 'absent' => 'puppetdb_termini',
+    default   => versioncmp($puppetdb_version, '2.3.0') ? {
+      -1      => 'puppetdb-terminus',
+      default => 'puppetdb-termini',
+    }
+  }
 
   package { $terminus_package:
     ensure => $puppetdb_version,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -64,7 +64,6 @@ class puppetdb::params {
   $puppetdb_group       = 'puppetdb'
   $confdir              = '/etc/puppetdb/conf.d'
   $puppet_confdir       = '/etc/puppet'
-  $terminus_package     = 'puppetdb-terminus'
   $ssl_dir              = '/etc/puppetdb/ssl'
 
   case $::osfamily {

--- a/spec/unit/classes/master/config_spec.rb
+++ b/spec/unit/classes/master/config_spec.rb
@@ -33,6 +33,15 @@ describe 'puppetdb::master::config', :type => :class do
         :puppetdb_server => 'puppetdb.example.com',
         :puppetdb_port => '8081',
         :use_ssl => 'true') }
+
+      it { should contain_package('puppetdb_termini').with( :ensure => 'present', )}
+    end
+
+    context 'when using an older puppetdb version' do
+
+      let(:pre_condition) { 'class { "puppetdb": puppetdb_version => "2.2.0" }' }
+      let(:params) do { :puppetdb_port => '1234' } end
+      it { should contain_package('puppetdb_terminus').with( :ensure => 'present', )}
     end
 
     context 'when puppetdb class is declared with disable_ssl => true' do
@@ -43,7 +52,7 @@ describe 'puppetdb::master::config', :type => :class do
         :puppetdb_port => '8080',
         :use_ssl => 'false')
       }
-      
+
     end
 
     context 'when puppetdb_port => 1234' do
@@ -72,6 +81,17 @@ describe 'puppetdb::master::config', :type => :class do
         :use_ssl => 'false')
       }
 
+    end
+
+    context 'when using default values' do
+      let(:pre_condition) { 'class { "puppetdb": }' }
+      it { should contain_package('puppetdb_termini').with( :ensure => 'present' )}
+    end
+
+    context 'when using an older puppetdb version' do
+      let(:pre_condition) { 'class { "puppetdb": puppetdb_version => "2.2.0", }' }
+      let(:params) do { :puppetdb_version => '2.2.0' } end
+      it { should contain_package('puppetdb_terminus').with( :ensure => 'present' )}
     end
 
   end


### PR DESCRIPTION
This PR sets the terminus package-name dynamically based on the version of PuppetDB we're using. 