### PR TITLE
Pin rspec to 3.1.7 so we avoid the ruby 1.8.7 errrors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 group :development, :test do
   gem 'rake'
   gem 'puppetlabs_spec_helper', :require => false
+  # Pinning due to bug in newer rspec with Ruby 1.8.7
+  gem 'rspec-core', '3.1.7'
   gem 'rspec-puppet', '~> 1.0'
   gem 'puppet-lint',  '~> 1.1'
 end


### PR DESCRIPTION
Seems rspec 3.2.0 broke on Ruby 1.8.7. This does a pinning so we can avoid the
issue.

Signed-off-by: Ken Barber <ken@bob.sh>