### PR TITLE
(bugfix) Use test_url in connection validator for puppetdb

### DIFF
--- a/lib/puppet/provider/puppetdb_conn_validator/puppet_https.rb
+++ b/lib/puppet/provider/puppetdb_conn_validator/puppet_https.rb
@@ -65,7 +65,7 @@ Puppet::Type.type(:puppetdb_conn_validator).provide(:puppet_https) do
   #
   # @api private
   def validator
-    @validator ||= Puppet::Util::PuppetdbValidator.new(resource[:puppetdb_server], resource[:puppetdb_port], resource[:use_ssl])
+    @validator ||= Puppet::Util::PuppetdbValidator.new(resource[:puppetdb_server], resource[:puppetdb_port], resource[:use_ssl], resource[:test_url])
   end
 
 end


### PR DESCRIPTION
This commit addresses an issue where the provider for
puppetConnValidator was not using the test_url specified by the
resource. This commit passes the param from the initializer to the utils
class.