### PR TITLE
(MODULES-1917) Ignore `._` files when building the module tarball

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,17 @@ Release notes for the puppetlabs-puppetdb module.
 
 ------------------------------------------
 
-#### 4.2.0 - 2014/04/02
+#### 4.2.1 - 2015/04/07
+
+This is a minor bugfix release.
+
+Detailed Changes:
+
+* Ignore `._foo` files when building the `.tar.gz` of the module.
+
+------------------------------------------
+
+#### 4.2.0 - 2015/04/02
 
 This is a minor feature release.
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "puppetlabs-puppetdb",
-    "version": "4.2.0",
+    "version": "4.2.1",
     "summary": "Installs PostgreSQL and PuppetDB, sets up the connection to Puppet master.",
     "source": "git://github.com/puppetlabs/puppetlabs-puppetdb.git",
     "project_page": "http://github.com/puppetlabs/puppetlabs-puppetdb",


### PR DESCRIPTION
Version bump to build a version without `._` files.