### PR TITLE
Enable the module to manage entries in $confdir/config.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,18 @@ Contents of your SSL CA certificate, as a string.
 
 if true, puppet will manage your iptables rules for puppetdb via the [puppetlabs-firewall](https://forge.puppetlabs.com/puppetlabs/firewall) class.
 
+####`command_threads`
+
+The number of command processing threads to use. Defaults to undef, using the PuppetDB built-in default.
+
+####`store_usage`
+
+The amount of disk space (in MB) to allow for persistent message storage. Defaults to undef, using the PuppetDB built-in default.
+
+####`temp_usage`
+
+The amount of disk space (in MB) to allow for temporary message storage. Defaults to undef, using the PuppetDB built-in default.
+
 
 ### puppetdb::server
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,6 +60,9 @@ class puppetdb (
   $manage_firewall          = $puppetdb::params::manage_firewall,
   $java_args                = $puppetdb::params::java_args,
   $max_threads              = $puppetdb::params::max_threads,
+  $command_threads          = $puppetdb::params::command_threads,
+  $store_usage              = $puppetdb::params::store_usage,
+  $temp_usage               = $puppetdb::params::temp_usage
 ) inherits puppetdb::params {
 
   class { '::puppetdb::server':
@@ -118,6 +121,9 @@ class puppetdb (
     puppetdb_user             => $puppetdb_user,
     puppetdb_group            => $puppetdb_group,
     manage_firewall           => $manage_firewall,
+    command_threads           => $command_threads,
+    store_usage               => $store_usage,
+    temp_usage                => $temp_usage,
   }
 
   if ($database == 'postgres') {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -125,6 +125,10 @@ class puppetdb::params {
   $puppetdb_startup_timeout = 120
   $puppetdb_service_status  = 'running'
 
+  $command_threads          = undef
+  $store_usage              = undef
+  $temp_usage               = undef
+
   $ssl_set_cert_paths        = false
   $ssl_cert_path             = "${ssl_dir}/public.pem"
   $ssl_key_path              = "${ssl_dir}/private.pem"

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -55,6 +55,9 @@ class puppetdb::server (
   $manage_firewall          = $puppetdb::params::manage_firewall,
   $java_args                = $puppetdb::params::java_args,
   $max_threads              = $puppetdb::params::max_threads,
+  $command_threads          = $puppetdb::params::command_threads,
+  $store_usage              = $puppetdb::params::store_usage,
+  $temp_usage               = $puppetdb::params::temp_usage,
 ) inherits puppetdb::params {
 
   # Apply necessary suffix if zero is specified.
@@ -114,6 +117,13 @@ class puppetdb::server (
       ssl_port       => $ssl_listen_port,
       open_ssl_port  => $open_ssl_listen_port,
     }
+  }
+
+  class { 'puppetdb::server::config_ini':
+    command_threads => $command_threads,
+    store_usage     => $store_usage,
+    temp_usage      => $temp_usage,
+    confdir         => $confdir,
   }
 
   class { 'puppetdb::server::database_ini':
@@ -238,11 +248,13 @@ class puppetdb::server (
   if $manage_firewall {
     Package[$puppetdb_package] ->
     Class['puppetdb::server::firewall'] ->
+    Class['puppetdb::server::config_ini'] ->
     Class['puppetdb::server::database_ini'] ->
     Class['puppetdb::server::jetty_ini'] ->
     Service[$puppetdb_service]
   } else {
     Package[$puppetdb_package] ->
+    Class['puppetdb::server::config_ini'] ->
     Class['puppetdb::server::database_ini'] ->
     Class['puppetdb::server::jetty_ini'] ->
     Service[$puppetdb_service]

--- a/manifests/server/config_ini.pp
+++ b/manifests/server/config_ini.pp
@@ -1,0 +1,58 @@
+# PRIVATE CLASS - do not use directly
+class puppetdb::server::config_ini (
+  $command_threads = $puppetdb::params::command_threads,
+  $store_usage     = $puppetdb::params::store_usage,
+  $temp_usage      = $puppetdb::params::temp_usage,
+  $confdir         = $puppetdb::params::confdir,
+) inherits puppetdb::params {
+
+
+  file { "${confdir}/config.ini":
+    ensure => 'present',
+    mode   => '0644',
+  }
+
+  # Set the defaults
+  Ini_setting {
+    path    => "${confdir}/config.ini",
+    ensure  => 'present',
+    section => 'command-processing',
+    require => File["${confdir}/config.ini"],
+  }
+
+  if $command_threads {
+    ini_setting { 'puppetdb_config_command_processing_threads':
+      setting => 'threads',
+      value   => $command_threads,
+    }
+  } else {
+    ini_setting { 'puppetdb_config_command_processing_threads':
+      ensure  => 'absent',
+      setting => 'threads',
+    }
+  }
+
+  if $store_usage {
+    ini_setting { 'puppetdb_config_command_processing_store_usage':
+      setting => 'store-usage',
+      value   => $store_usage,
+    }
+  } else {
+    ini_setting { 'puppetdb_config_command_processing_store_usage':
+      ensure  => 'absent',
+      setting => 'store-usage',
+    }
+  }
+
+  if $temp_usage {
+    ini_setting { 'puppetdb_config_command_processing_temp_usage':
+      setting => 'temp-usage',
+      value   => $temp_usage,
+    }
+  } else {
+    ini_setting { 'puppetdb_config_command_processing_temp_usage':
+      ensure  => 'absent',
+      setting => 'temp-usage',
+    }
+  }
+}

--- a/spec/unit/classes/server/config_ini_spec.rb
+++ b/spec/unit/classes/server/config_ini_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe 'puppetdb::server::config_ini', :type => :class do
+  context 'on a supported platform' do
+    let(:facts) do
+      {
+        :osfamily                 => 'OpenBSD',
+      }
+    end
+
+    it { should contain_class('puppetdb::server::config_ini') }
+
+    describe 'when using default values' do
+      it { should contain_ini_setting('puppetdb_config_command_processing_threads').
+        with(
+             'ensure'  => 'absent',
+             'path'    => '/etc/puppetdb/conf.d/config.ini',
+             'section' => 'command-processing',
+             'setting' => 'threads'
+             )}
+      it { should contain_ini_setting('puppetdb_config_command_processing_store_usage').
+        with(
+             'ensure'  => 'absent',
+             'path'    => '/etc/puppetdb/conf.d/config.ini',
+             'section' => 'command-processing',
+             'setting' => 'store-usage'
+             )}
+      it { should contain_ini_setting('puppetdb_config_command_processing_temp_usage').
+        with(
+             'ensure'  => 'absent',
+             'path'    => '/etc/puppetdb/conf.d/config.ini',
+             'section' => 'command-processing',
+             'setting' => 'temp-usage'
+             )}
+    end
+
+    describe 'when using custom values' do
+      let(:params) do
+        {
+          'command_threads' => 10,
+          'store_usage'     => 4000,
+          'temp_usage'      => 2000,
+        }
+      end
+      it { should contain_ini_setting('puppetdb_config_command_processing_threads').
+        with(
+             'ensure'  => 'present',
+             'path'    => '/etc/puppetdb/conf.d/config.ini',
+             'section' => 'command-processing',
+             'setting' => 'threads',
+             'value'   => '10'
+             )}
+      it { should contain_ini_setting('puppetdb_config_command_processing_store_usage').
+        with(
+             'ensure'  => 'present',
+             'path'    => '/etc/puppetdb/conf.d/config.ini',
+             'section' => 'command-processing',
+             'setting' => 'store-usage',
+             'value'   => '4000'
+             )}
+      it { should contain_ini_setting('puppetdb_config_command_processing_temp_usage').
+        with(
+             'ensure'  => 'present',
+             'path'    => '/etc/puppetdb/conf.d/config.ini',
+             'section' => 'command-processing',
+             'setting' => 'temp-usage',
+             'value'   => '2000'
+             )}
+    end
+  end
+end


### PR DESCRIPTION
with regard to the command-processing section.

Added new class server/config_ini.pp to manage contents of the config.ini.
Three new parameters added:
  * command_threads
  * store_usage
  * temp_usage

All three default to 'undef'. This makes sure (potential) custom settings
done to that file with regard to above three variables are 'absent',
and let PuppetDB built-in defaults take care.

Documentation to the README.md added, as well as unit tests.

My use-case was, that I have on some nodes a too small /var partition,
so I had to lower the values of store-usage and temp-usage in the config.ini
manually.