### PR TITLE
(maint) Add file_concat and bump rspec versions

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,5 +6,6 @@ fixtures:
     firewall: 'git://github.com/puppetlabs/puppetlabs-firewall.git'
     apt: 'git://github.com/puppetlabs/puppetlabs-apt.git'
     concat: 'git://github.com/puppetlabs/puppetlabs-concat.git'
+    file_concat: 'git://github.com/electrical/puppet-lib-file_concat.git'
   symlinks:
     puppetdb: '#{source_dir}'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ group :development, :test do
   gem 'puppetlabs_spec_helper', :require => false
   # Pinning due to bug in newer rspec with Ruby 1.8.7
   gem 'rspec-core', '3.1.7'
-  gem 'rspec-puppet', '~> 1.0'
+  gem 'rspec-puppet', '~> 2.0'
   gem 'puppet-lint',  '~> 1.1'
   gem 'metadata-json-lint'
 end

--- a/spec/unit/util/puppetdb_validator_spec.rb
+++ b/spec/unit/util/puppetdb_validator_spec.rb
@@ -28,13 +28,13 @@ describe 'Puppet::Util::PuppetdbValidator' do
 
   it 'returns true if connection succeeds' do
     validator = Puppet::Util::PuppetdbValidator.new('mypuppetdb.com', 8081)
-    validator.attempt_connection.should be true
+    expect(validator.attempt_connection).to be true
   end
 
   it 'should still validate without ssl' do
     Puppet[:configtimeout] = 2
     validator = Puppet::Util::PuppetdbValidator.new('mypuppetdb.com', 8080, false)
-    validator.attempt_connection.should be true
+    expect(validator.attempt_connection).to be true
   end
 
   it 'returns false and issues an appropriate notice if connection is refused' do
@@ -42,7 +42,7 @@ describe 'Puppet::Util::PuppetdbValidator' do
     puppetdb_port = 8080
     validator = Puppet::Util::PuppetdbValidator.new(puppetdb_server, puppetdb_port)
     Puppet.expects(:notice).with("Unable to connect to puppetdb server (https://#{puppetdb_server}:#{puppetdb_port}): Connection refused")
-    validator.attempt_connection.should be false
+    expect(validator.attempt_connection).to be false
   end
 
   it 'returns false and issues an appropriate notice if connection succeeds but puppetdb is not available' do
@@ -50,7 +50,7 @@ describe 'Puppet::Util::PuppetdbValidator' do
     puppetdb_port = 8081
     validator = Puppet::Util::PuppetdbValidator.new(puppetdb_server, puppetdb_port)
     Puppet.expects(:notice).with("Unable to connect to puppetdb server (https://#{puppetdb_server}:#{puppetdb_port}): [404] Not found")
-    validator.attempt_connection.should be false
+    expect(validator.attempt_connection).to be false
   end
 
   it 'returns false and issues an appropriate notice if host:port is unreachable or does not exist' do
@@ -58,7 +58,7 @@ describe 'Puppet::Util::PuppetdbValidator' do
     puppetdb_port = nil
     validator = Puppet::Util::PuppetdbValidator.new(puppetdb_server, puppetdb_port)
     Puppet.expects(:notice).with("Unable to connect to puppetdb server (https://#{puppetdb_server}:#{puppetdb_port}): Unknown host")
-    validator.attempt_connection.should be false
+    expect(validator.attempt_connection).to be false
   end
 
 end


### PR DESCRIPTION
This fixes the file_concat dependency issue postgresql module has brought in,
plus bumps some other dependencies and removes some deprecation warnings from
our tests.

Signed-off-by: Ken Barber <ken@bob.sh>