### PR TITLE
(PDB-1035) Add default PuppetDB root context

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,15 @@ You can also manually trigger puppet runs on the nodes in the correct order (Pos
 Upgrading
 ---------
 
+###Upgrading from 4.x to version 5.x
+
+Significant parameter changes are listed below:
+
+* The PuppetDB module now supports PuppetDB 3.0.0 by default
+* If you want to use 5.x of the module with PuppetDB 2.x, you'll need to set the `test_url => /v3/version` and either `puppetdb_version => 2.y.z` or `terminus_package => 2.y.z`
+
+See the CHANGELOG file for more detailed information on changes for each release.
+
 ###Upgrading from 3.x to version 4.x
 
 For this release, all dependency versions have been bumped to their latest. Significant parameter changes are listed below:
@@ -557,7 +566,7 @@ Conditionally manages the PostgresQL server via `postgresql::server`. Defaults t
 
 ####`test_url`
 
-The URL to use for testing if the PuppetDB instance is running. Defaults to `/v3/version`.
+The URL to use for testing if the PuppetDB instance is running. Defaults to `/pdb/meta/v1/version`.
 
 ####`manage_package_repo`
 

--- a/lib/puppet/util/puppetdb_validator.rb
+++ b/lib/puppet/util/puppetdb_validator.rb
@@ -10,7 +10,7 @@ module Puppet
       attr_reader :test_path
       attr_reader :test_headers
 
-      def initialize(puppetdb_server, puppetdb_port, use_ssl=true, test_path = "/v3/version")
+      def initialize(puppetdb_server, puppetdb_port, use_ssl=true, test_path = "/pdb/meta/v1/version")
         @puppetdb_server = puppetdb_server
         @puppetdb_port   = puppetdb_port
         @use_ssl         = use_ssl

--- a/manifests/master/puppetdb_conf.pp
+++ b/manifests/master/puppetdb_conf.pp
@@ -16,14 +16,9 @@ class puppetdb::master::puppetdb_conf (
     path    => "${puppet_confdir}/puppetdb.conf",
   }
 
-  ini_setting { 'puppetdbserver':
-    setting => 'server',
-    value   => $server,
-  }
-
-  ini_setting { 'puppetdbport':
-    setting => 'port',
-    value   => $port,
+  ini_setting { 'puppetdbserver_urls':
+    setting => 'server_urls',
+    value   => "https://#{server}:#{port}/",
   }
 
   ini_setting { 'soft_write_failure':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -58,14 +58,13 @@ class puppetdb::params {
 
   $manage_firewall = true
   $java_args       = {}
-  $test_url        = '/v3/version'
+  $test_url        = '/pdb/meta/v1/version'
 
   $puppetdb_package     = 'puppetdb'
   $puppetdb_service     = 'puppetdb'
   $puppetdb_user        = 'puppetdb'
   $puppetdb_group       = 'puppetdb'
   $masterless           = false
-  $terminus_package     = 'puppetdb-terminus'
 
   case $::osfamily {
     'RedHat', 'Suse', 'Archlinux': {

--- a/spec/unit/classes/master/config_spec.rb
+++ b/spec/unit/classes/master/config_spec.rb
@@ -26,52 +26,52 @@ describe 'puppetdb::master::config', :type => :class do
   context 'when PuppetDB and Puppet Master are on the same server' do
 
     context 'when using default values' do
-
       let(:pre_condition) { 'class { "puppetdb": }' }
 
       it { should contain_puppetdb_conn_validator('puppetdb_conn').with(
-        :puppetdb_server => 'puppetdb.example.com',
-        :puppetdb_port => '8081',
-        :use_ssl => 'true') }
+                    :puppetdb_server => 'puppetdb.example.com',
+                    :puppetdb_port => '8081',
+                    :use_ssl => 'true') }
     end
 
     context 'when puppetdb class is declared with disable_ssl => true' do
-
       let(:pre_condition) { 'class { "puppetdb": disable_ssl => true }' }
 
       it { should contain_puppetdb_conn_validator('puppetdb_conn').with(
-        :puppetdb_port => '8080',
-        :use_ssl => 'false')
-      }
-      
+                    :puppetdb_port => '8080',
+                    :use_ssl => 'false')}
     end
 
     context 'when puppetdb_port => 1234' do
-
       let(:pre_condition) { 'class { "puppetdb": }' }
-
       let(:params) do { :puppetdb_port => '1234' } end
 
       it { should contain_puppetdb_conn_validator('puppetdb_conn').with(
-        :puppetdb_port => '1234',
-        :use_ssl => 'true')
-      }
-
+                    :puppetdb_port => '1234',
+                    :use_ssl => 'true')}
     end
 
     context 'when puppetdb_port => 1234 AND the puppetdb class is declared with disable_ssl => true' do
-
       let(:pre_condition) { 'class { "puppetdb": disable_ssl => true }' }
-
-      let(:params) do {
-        :puppetdb_port => '1234'
-      } end
+      let(:params) do {:puppetdb_port => '1234'} end
 
       it { should contain_puppetdb_conn_validator('puppetdb_conn').with(
-        :puppetdb_port => '1234',
-        :use_ssl => 'false')
-      }
+                    :puppetdb_port => '1234',
+                    :use_ssl => 'false')}
 
+    end
+    
+    context 'when using default values' do
+      let (:pre_condition) { 'class { "puppetdb": }' }
+      
+      it { should contain_package('puppetdb-termini').with( :ensure => 'present' )}
+    end
+    
+    context 'when using an older puppetdb version' do
+      let (:pre_condition) { 'class { "puppetdb": puppetdb_version => "2.2.0", }' }
+      let (:params) do { :puppetdb_version => '2.2.0' } end
+      
+      it { should contain_package('puppetdb-terminus').with( :ensure => '2.2.0' )}
     end
 
   end

--- a/spec/unit/util/puppetdb_validator_spec.rb
+++ b/spec/unit/util/puppetdb_validator_spec.rb
@@ -12,12 +12,12 @@ describe 'Puppet::Util::PuppetdbValidator' do
     response_not_found.stubs(:msg).returns('Not found')
 
     conn_ok = stub()
-    conn_ok.stubs(:get).with('/v3/version', {"Accept" => "application/json"}).returns(response_ok)
+    conn_ok.stubs(:get).with('/pdb/meta/v1/version', {"Accept" => "application/json"}).returns(response_ok)
     conn_ok.stubs(:read_timeout=).with(2)
     conn_ok.stubs(:open_timeout=).with(2)
 
     conn_not_found = stub()
-    conn_not_found.stubs(:get).with('/v3/version', {"Accept" => "application/json"}).returns(response_not_found)
+    conn_not_found.stubs(:get).with('/pdb/meta/v1/version', {"Accept" => "application/json"}).returns(response_not_found)
 
     Puppet::Network::HttpPool.stubs(:http_instance).raises('Unknown host')
     Puppet::Network::HttpPool.stubs(:http_instance).with('mypuppetdb.com', 8080, true).raises('Connection refused')


### PR DESCRIPTION
This commit changes the terminus configuration to use the new root
prefix for PuppetDB and changes the connection validator to do the same.