### PR TITLE
(maint) Allow database_validation to be false

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -127,6 +127,12 @@ class puppetdb (
   }
 
   if ($database == 'postgres') {
+    
+    $database_before = str2bool($database_validate) ? {
+      false => Class['::puppetdb::server'],
+      default => [Class['::puppetdb::server'], Class['::puppetdb::server::validate_db']],
+    }
+    
     class { '::puppetdb::database::postgresql':
       listen_addresses    => $database_listen_address,
       database_name       => $database_name,
@@ -135,7 +141,7 @@ class puppetdb (
       manage_server       => $manage_dbserver,
       manage_package_repo => $manage_package_repo,
       postgres_version    => $postgres_version,
-      before              => [Class['::puppetdb::server'], Class['::puppetdb::server::validate_db']],
+      before              => $database_before
     }
   }
 }


### PR DESCRIPTION
This commit fixes a bug where if a user tried to turn off database
validation there would be a `before` statement requiring an absent
validation resource.