### PR TITLE
(maint) Add ability to manage old terminus style

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Significant parameter changes are listed below:
 
 * The PuppetDB module now supports PuppetDB 3.0.0 by default
 * If you want to use 5.x of the module with PuppetDB 2.x, you'll need to set the `test_url => /v3/version` and either `puppetdb_version => 2.y.z` or `terminus_package => 2.y.z`
+* The `puppetdb::master:puppetdb_conf` class has added a `$legacy_terminus` parameter which will be set the correct default if you set `puppetdb_version => 2.y.z` or `terminus_package => 2.y.z` like above but if you use the class directly *and* you're using PuppetDB 2.x, you will need to change `$legacy_terminus` to true.
+
 
 See the CHANGELOG file for more detailed information on changes for each release.
 

--- a/README.md
+++ b/README.md
@@ -144,9 +144,23 @@ Upgrading
 Significant parameter changes are listed below:
 
 * The PuppetDB module now supports PuppetDB 3.0.0 by default
-* If you want to use 5.x of the module with PuppetDB 2.x, you'll need to set the `test_url => /v3/version` and either `puppetdb_version => 2.y.z` or `terminus_package => 2.y.z`
-* The `puppetdb::master:puppetdb_conf` class has added a `$legacy_terminus` parameter which will be set the correct default if you set `puppetdb_version => 2.y.z` or `terminus_package => 2.y.z` like above but if you use the class directly *and* you're using PuppetDB 2.x, you will need to change `$legacy_terminus` to true.
-
+* If you want to use 5.x of the module with PuppetDB 2.x, you'll need to set `puppetdb_version => 2.y.z` or `terminus_package => 2.y.z`
+* The `puppetdb::master:puppetdb_conf` class has added a `$legacy_terminus` parameter which will be set the correct default if you set `puppetdb_version => 2.y.z` or `terminus_package => 2.y.z`.
+* The default `test_url` for the `PuppetDBConnValidator` has also been chaged to `/pdb/meta/v1/version` but will also be set the correct default if you set `puppetdb_version => 2.y.z` or `terminus_package => 2.y.z`.
+For example if your config looked like this before:
+~~~ruby
+class { 'puppetdb::master::config':
+      puppetdb_server => 'foo.example.com',
+      puppetdb_version => present,
+}
+~~~
+and you'd still like to use the module with PuppetDB 2.3.5, all you'd have to change would be:
+~~~ruby
+class { 'puppetdb::master::config':
+      puppetdb_server => 'foo.example.com',
+      terminus_package => '2.3.5',
+}
+~~~
 
 See the CHANGELOG file for more detailed information on changes for each release.
 

--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -126,6 +126,7 @@ class puppetdb::master::config (
       port               => $puppetdb_port,
       soft_write_failure => $puppetdb_soft_write_failure,
       puppet_confdir     => $puppet_confdir,
+      legacy_terminus    => $terminus_package_name == 'puppetdb-terminus',
       require            => $strict_validation ? {
         true    => Puppetdb_conn_validator['puppetdb_conn'],
         default => Package[$terminus_package_name],

--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -26,7 +26,7 @@ class puppetdb::master::config (
   $terminus_package            = '',
   $puppet_service_name         = $puppetdb::params::puppet_service_name,
   $puppetdb_startup_timeout    = $puppetdb::params::puppetdb_startup_timeout,
-  $test_url                    = $puppetdb::params::test_url,
+  $test_url                    = '',
   $restart_puppet              = true,
 ) inherits puppetdb::params {
 
@@ -45,6 +45,16 @@ class puppetdb::master::config (
 
   package { $terminus_package_name:
     ensure => $puppetdb_version,
+  }
+
+  if empty($test_url) {
+    if $terminus_package_name == 'puppetdb-terminus' {
+      $terminus_test_url = '/v3/version'
+    } else {
+      $terminus_test_url = '/pdb/meta/v1/version'
+    }
+  } else {
+    $terminus_test_url = $test_url
   }
 
   if ($strict_validation) {
@@ -66,7 +76,7 @@ class puppetdb::master::config (
       },
       timeout         => $puppetdb_startup_timeout,
       require         => Package[$terminus_package_name],
-      test_url        => $test_url,
+      test_url        => $terminus_test_url,
     }
 
     # This is a bit of puppet chicanery that allows us to create a

--- a/manifests/master/puppetdb_conf.pp
+++ b/manifests/master/puppetdb_conf.pp
@@ -8,6 +8,7 @@ class puppetdb::master::puppetdb_conf (
     default => false,
   },
   $puppet_confdir     = $puppetdb::params::puppet_confdir,
+  $legacy_terminus    = false,
 ) inherits puppetdb::params {
 
   Ini_setting {
@@ -16,9 +17,20 @@ class puppetdb::master::puppetdb_conf (
     path    => "${puppet_confdir}/puppetdb.conf",
   }
 
-  ini_setting { 'puppetdbserver_urls':
-    setting => 'server_urls',
-    value   => "https://#{server}:#{port}/",
+  if $legacy_terminus {
+    ini_setting { 'puppetdbserver':
+      setting => 'server',
+      value   => $server,
+    }
+    ini_setting { 'puppetdbport':
+      setting => 'port',
+      value   => $port,
+    }
+  } else {
+    ini_setting { 'puppetdbserver_urls':
+      setting => 'server_urls',
+      value   => "https://${server}:${port}/",
+    }
   }
 
   ini_setting { 'soft_write_failure':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -58,7 +58,6 @@ class puppetdb::params {
 
   $manage_firewall = true
   $java_args       = {}
-  $test_url        = '/pdb/meta/v1/version'
 
   $puppetdb_package     = 'puppetdb'
   $puppetdb_service     = 'puppetdb'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -96,7 +96,7 @@ class puppetdb::server (
     fail("puppetdb_service_status valid values are 'true', 'running', 'false', and 'stopped'. You provided '${puppetdb_service_status}'")
   }
 
-  # Validate read-database type (Currently only postgres is supported)
+  # Validate database type (Currently only postgres and embedded are supported)
   if !($database in ['postgres', 'embedded']) {
     fail("database must must be 'postgres' or 'embedded'. You provided '${database}'")
   }

--- a/spec/unit/classes/master/config_spec.rb
+++ b/spec/unit/classes/master/config_spec.rb
@@ -65,6 +65,7 @@ describe 'puppetdb::master::config', :type => :class do
       let (:pre_condition) { 'class { "puppetdb": }' }
       
       it { should contain_package('puppetdb-termini').with( :ensure => 'present' )}
+      it { should contain_puppetdb_conn_validator('puppetdb_conn').with(:test_url => '/pdb/meta/v1/version')}
     end
     
     context 'when using an older puppetdb version' do
@@ -72,6 +73,7 @@ describe 'puppetdb::master::config', :type => :class do
       let (:params) do { :puppetdb_version => '2.2.0' } end
       
       it { should contain_package('puppetdb-terminus').with( :ensure => '2.2.0' )}
+      it { should contain_puppetdb_conn_validator('puppetdb_conn').with(:test_url => '/v3/version')}
     end
 
   end

--- a/spec/unit/classes/master/puppetdb_conf_spec.rb
+++ b/spec/unit/classes/master/puppetdb_conf_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'puppetdb::master::puppetdb_conf', :type => :class do
+
+  let(:facts) do
+    {
+      :fqdn => 'puppetdb.example.com',
+      :osfamily => 'Debian',
+      :operatingsystem => 'Debian',
+      :operatingsystemrelease => '6.0',
+      :kernel => 'Linux',
+      :concat_basedir => '/var/lib/puppet/concat',
+      :id => 'root',
+      :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+  
+  let(:pre_condition) { 'class { "puppetdb": }' }
+  
+  context 'when using using default values' do
+    it { should contain_ini_setting('puppetdbserver_urls').with( :value => 'https://localhost:8081/' )}
+  end
+  
+  context 'when using using default values' do
+    let (:params) do { :legacy_terminus => true, } end
+    it { should contain_ini_setting('puppetdbserver').with( :value => 'localhost' )}
+    it { should contain_ini_setting('puppetdbport').with( :value => '8081' )}
+  end
+  
+end


### PR DESCRIPTION
This commit adds the ability to manage to legacy style of terminus for
`PuppetDB 2.x`.