### PR TITLE
PuppetDB version can be provided from main puppetdb class instead fro…

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -1,5 +1,4 @@
 class puppetdb::globals (
-  $version                      = 'present',
   $database                     = 'postgres',
   ) {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,7 @@ class puppetdb (
   $conn_keep_alive          = $puppetdb::params::conn_keep_alive,
   $conn_lifetime            = $puppetdb::params::conn_lifetime,
   $puppetdb_package         = $puppetdb::params::puppetdb_package,
+  $puppetdb_version         = $puppetdb::params::puppetdb_version,
   $puppetdb_service         = $puppetdb::params::puppetdb_service,
   $puppetdb_service_status  = $puppetdb::params::puppetdb_service_status,
   $puppetdb_user            = $puppetdb::params::puppetdb_user,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class puppetdb::params inherits puppetdb::globals {
   $open_ssl_listen_port      = undef
   $postgres_listen_addresses = 'localhost'
 
-  $puppetdb_version          = $puppetdb::globals::version
+  $puppetdb_version          = '2.3.6-1.el6'
   $database                  = $puppetdb::globals::database
   $manage_dbserver           = true
   $manage_pg_repo            = true


### PR DESCRIPTION
…m globles, as version comparison condition is getting failed for redhat/centos system which leads to wrong configuration location