### PR TITLE
Fix unmanaged postgresql database port

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -5,6 +5,7 @@ class puppetdb::database::postgresql(
   $database_name        = $puppetdb::params::database_name,
   $database_username    = $puppetdb::params::database_username,
   $database_password    = $puppetdb::params::database_password,
+  $database_port        = $puppetdb::params::database_port,
   $manage_server        = $puppetdb::params::manage_dbserver,
   $manage_package_repo  = $puppetdb::params::manage_pg_repo,
   $postgres_version     = $puppetdb::params::postgres_version,
@@ -19,6 +20,7 @@ class puppetdb::database::postgresql(
     class { '::postgresql::server':
       ip_mask_allow_all_users => '0.0.0.0/0',
       listen_addresses        => $listen_addresses,
+      port                    => $database_port,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -138,6 +138,7 @@ class puppetdb (
       database_name       => $database_name,
       database_username   => $database_username,
       database_password   => $database_password,
+      database_port       => $database_port,
       manage_server       => $manage_dbserver,
       manage_package_repo => $manage_package_repo,
       postgres_version    => $postgres_version,


### PR DESCRIPTION
Useful for when this module wants to install PGDG postgresql-9.4 on a CentOS 7 system with postgresql 9.2 already running (e.g. foreman)