### PR TITLE
MODULES-2488 Use dport instead of the now deprecated port parameter

### DIFF
--- a/manifests/server/firewall.pp
+++ b/manifests/server/firewall.pp
@@ -9,7 +9,7 @@ class puppetdb::server::firewall (
 
   if ($open_http_port) {
     firewall { "${http_port} accept - puppetdb":
-      port   => $http_port,
+      dport  => $http_port,
       proto  => 'tcp',
       action => 'accept',
     }
@@ -17,7 +17,7 @@ class puppetdb::server::firewall (
 
   if ($open_ssl_port) {
     firewall { "${ssl_port} accept - puppetdb":
-      port   => $ssl_port,
+      dport  => $ssl_port,
       proto  => 'tcp',
       action => 'accept',
     }


### PR DESCRIPTION
Use of "port" is deprecated and adds a too relaxed firewall rule to the system:
https://github.com/roman-mueller/puppetlabs-firewall/commit/4f2df97faab93e530ff5a4d99afa3d9d16a246cd
It will also be removed in the future.
Use dport instead in the manifest.