### PR TITLE
MODULES-2556 add postgres_datadir parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,6 +609,10 @@ Conditionally manages the PostgresQL server via `postgresql::server`. Defaults t
 
 The URL to use for testing if the PuppetDB instance is running. Defaults to `/pdb/meta/v1/version`.
 
+####`postgres_datadir`
+
+This setting will override the default postgresql data directory, e.g. `/pgdata`.  The default is to let the postgresql module use whatever directory is the default for your OS distro.
+
 ####`manage_package_repo`
 
 If this is true, the official postgres.org repo will be added and postgres won't be installed from the regular repository. This setting defaults to `true`.

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -8,6 +8,7 @@ class puppetdb::database::postgresql(
   $database_port        = $puppetdb::params::database_port,
   $manage_server        = $puppetdb::params::manage_dbserver,
   $manage_package_repo  = $puppetdb::params::manage_pg_repo,
+  $postgres_datadir     = $puppetdb::params::postgres_datadir,
   $postgres_version     = $puppetdb::params::postgres_version,
 ) inherits puppetdb::params {
 
@@ -15,6 +16,7 @@ class puppetdb::database::postgresql(
     class { '::postgresql::globals':
       manage_package_repo => $manage_package_repo,
       version             => $postgres_version,
+      datadir             => $postgres_datadir,
     }
     # get the pg server up and running
     class { '::postgresql::server':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,7 @@ class puppetdb (
   $ssl_protocols                     = $puppetdb::params::ssl_protocols,
   $manage_dbserver                   = $puppetdb::params::manage_dbserver,
   $manage_package_repo               = $puppetdb::params::manage_pg_repo,
+  $postgres_datadir                  = $puppetdb::params::postgres_datadir,
   $postgres_version                  = $puppetdb::params::postgres_version,
   $database                          = $puppetdb::params::database,
   $database_host                     = $puppetdb::params::database_host,
@@ -145,6 +146,7 @@ class puppetdb (
       database_port       => $database_port,
       manage_server       => $manage_dbserver,
       manage_package_repo => $manage_package_repo,
+      postgres_datadir    => $postgres_datadir,
       postgres_version    => $postgres_version,
       before              => $database_before
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,7 @@ class puppetdb::params inherits puppetdb::globals {
   $database                  = $puppetdb::globals::database
   $manage_dbserver           = true
   $manage_pg_repo            = true
+  $postgres_datadir          = undef
   $postgres_version          = '9.4'
 
   # The remaining database settings are not used for an embedded database


### PR DESCRIPTION
This PR includes parametrization of the PostgreSQL datadir for PuppetDB (which otherwise just uses the puppetlabs-postgresql module default).  This allows locating PostgreSQL data outside of the host's root volume for performance advantage, i.e. on a faster AWS volume or hard disk with higher RPM.