### PR TITLE
(maint) Lint fixes

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -1,3 +1,4 @@
+# Global configuration class for PuppetDB. See README.md for more details.
 class puppetdb::globals (
   $version                      = 'present',
   $database                     = 'postgres',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -136,7 +136,8 @@ class puppetdb (
 
     $database_before = str2bool($database_validate) ? {
       false => Class['::puppetdb::server'],
-      default => [Class['::puppetdb::server'], Class['::puppetdb::server::validate_db']],
+      default => [Class['::puppetdb::server'],
+                  Class['::puppetdb::server::validate_db']],
     }
 
     class { '::puppetdb::database::postgresql':

--- a/manifests/master/routes.pp
+++ b/manifests/master/routes.pp
@@ -33,8 +33,9 @@ class puppetdb::master::routes (
   # TODO: this will overwrite any existing routes.yaml;
   #  to handle this properly we should just be ensuring
   #  that the proper settings exist, but to do that we'd need
-  #  to parse the yaml file and rewrite it, dealing with indentation issues etc.
-  #  I don't think there is currently a puppet module or an augeas lens for this.
+  #  to parse the yaml file and rewrite it, dealing with indentation issues etc
+  #  I don't think there is currently a puppet module or an augeas lens for
+  #  this.
   file { "${puppet_confdir}/routes.yaml":
     ensure  => file,
     content => template('puppetdb/routes.yaml.erb'),

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -72,7 +72,7 @@ class puppetdb::params inherits puppetdb::globals {
       'RedHat', 'Suse', 'Archlinux','Debian': {
         $confdir                = '/etc/puppetdb/conf.d'
         $vardir                 = '/var/lib/puppetdb'
-        $database_embedded_path = '${vardir}/db/db'
+        $database_embedded_path = "${vardir}/db/db"
         $puppet_confdir         = pick($settings::confdir,'/etc/puppet')
         $puppet_service_name    = 'puppetmaster'
         $ssl_dir                = '/etc/puppetdb/ssl'
@@ -80,7 +80,7 @@ class puppetdb::params inherits puppetdb::globals {
       'OpenBSD': {
         $confdir                = '/etc/puppetdb/conf.d'
         $vardir                 = '/var/db/puppetdb'
-        $database_embedded_path = '${vardir}/db/db'
+        $database_embedded_path = "${vardir}/db/db"
         $puppet_confdir         = pick($settings::confdir,'/etc/puppet')
         $puppet_service_name    = 'puppetmasterd'
         $ssl_dir                = '/etc/puppetdb/ssl'
@@ -88,10 +88,13 @@ class puppetdb::params inherits puppetdb::globals {
       'FreeBSD': {
         $confdir                = '/usr/local/etc/puppetdb/conf.d'
         $vardir                 = '/var/db/puppetdb'
-        $database_embedded_path = '${vardir}/db/db'
+        $database_embedded_path = "${vardir}/db/db"
         $puppet_confdir         = pick($settings::confdir,'/usr/local/etc/puppet')
         $puppet_service_name    = 'puppetmaster'
         $ssl_dir                = '/usr/local/etc/puppetdb/ssl'
+      }
+      default: {
+        fail("The fact 'osfamily' is set to ${::osfamily} which is not supported by the puppetdb module.")
       }
     }
     $terminus_package = 'puppetdb-terminus'
@@ -99,39 +102,45 @@ class puppetdb::params inherits puppetdb::globals {
   } else {
     case $::osfamily {
       'RedHat', 'Suse', 'Archlinux','Debian': {
-        $confdir                = '/etc/puppetlabs/puppetdb/conf.d'
-        $puppet_confdir         = pick($settings::confdir,'/etc/puppetlabs/puppet')
-        $puppet_service_name    = 'puppetserver'
-        $ssl_dir                = '/etc/puppetlabs/puppetdb/ssl'
+        $confdir             = '/etc/puppetlabs/puppetdb/conf.d'
+        $puppet_confdir      = pick($settings::confdir,'/etc/puppetlabs/puppet')
+        $puppet_service_name = 'puppetserver'
+        $ssl_dir             = '/etc/puppetlabs/puppetdb/ssl'
       }
       'OpenBSD': {
-        $confdir                = '/etc/puppetlabs/puppetdb/conf.d'
-        $puppet_confdir         = pick($settings::confdir,'/etc/puppetlabs/puppet')
-        $puppet_service_name    = undef
-        $ssl_dir                = '/etc/puppetlabs/puppetdb/ssl'
+        $confdir             = '/etc/puppetlabs/puppetdb/conf.d'
+        $puppet_confdir      = pick($settings::confdir,'/etc/puppetlabs/puppet')
+        $puppet_service_name = undef
+        $ssl_dir             = '/etc/puppetlabs/puppetdb/ssl'
       }
       'FreeBSD': {
-        $confdir                = '/usr/local/etc/puppetlabs/puppetdb/conf.d'
-        $puppet_confdir         = pick($settings::confdir,'/usr/local/etc/puppetlabs/puppet')
-        $puppet_service_name    = undef
-        $ssl_dir                = '/usr/local/etc/puppetlabs/puppetdb/ssl'
+        $confdir             = '/usr/local/etc/puppetlabs/puppetdb/conf.d'
+        $puppet_confdir      = pick($settings::confdir,'/usr/local/etc/puppetlabs/puppet')
+        $puppet_service_name = undef
+        $ssl_dir             = '/usr/local/etc/puppetlabs/puppetdb/ssl'
+      }
+      default: {
+        fail("The fact 'osfamily' is set to ${::osfamily} which is not supported by the puppetdb module.")
       }
     }
     $terminus_package       = 'puppetdb-termini'
     $test_url               = '/pdb/meta/v1/version'
     $vardir                 = '/opt/puppetlabs/server/data/puppetdb'
-    $database_embedded_path = '${vardir}/db/db'
+    $database_embedded_path = "${vardir}/db/db"
   }
 
   case $::osfamily {
     'RedHat', 'Suse', 'Archlinux': {
-      $puppetdb_initconf      = '/etc/sysconfig/puppetdb'
+      $puppetdb_initconf = '/etc/sysconfig/puppetdb'
     }
     'Debian': {
-      $puppetdb_initconf      = '/etc/default/puppetdb'
+      $puppetdb_initconf = '/etc/default/puppetdb'
     }
     'OpenBSD','FreeBSD': {
-      $puppetdb_initconf      = undef
+      $puppetdb_initconf = undef
+    }
+    default: {
+      fail("The fact 'osfamily' is set to ${::osfamily} which is not supported by the puppetdb module.")
     }
   }
 
@@ -143,13 +152,12 @@ class puppetdb::params inherits puppetdb::globals {
   $store_usage              = undef
   $temp_usage               = undef
 
-  $ssl_set_cert_paths        = false
-  $ssl_cert_path             = "${ssl_dir}/public.pem"
-  $ssl_key_path              = "${ssl_dir}/private.pem"
-  $ssl_ca_cert_path          = "${ssl_dir}/ca.pem"
-  $ssl_deploy_certs          = false
-  $ssl_key                   = undef
-  $ssl_cert                  = undef
-  $ssl_ca_cert               = undef
-
+  $ssl_set_cert_paths       = false
+  $ssl_cert_path            = "${ssl_dir}/public.pem"
+  $ssl_key_path             = "${ssl_dir}/private.pem"
+  $ssl_ca_cert_path         = "${ssl_dir}/ca.pem"
+  $ssl_deploy_certs         = false
+  $ssl_key                  = undef
+  $ssl_cert                 = undef
+  $ssl_ca_cert              = undef
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -181,7 +181,8 @@ class puppetdb::server (
     notify              => Service[$puppetdb_service],
   }
 
-  if str2bool($ssl_set_cert_paths) == true or str2bool($ssl_deploy_certs) == true {
+  if str2bool($ssl_set_cert_paths) == true
+  or str2bool($ssl_deploy_certs) == true {
     validate_absolute_path($ssl_key_path)
     validate_absolute_path($ssl_cert_path)
     validate_absolute_path($ssl_ca_cert_path)
@@ -240,24 +241,24 @@ class puppetdb::server (
       create_resources(
         'ini_subsetting',
         puppetdb_create_subsetting_resource_hash(
-          $java_args,
-          {ensure  => present,
-           section => '',
-           key_val_separator => '=',
-           path => $puppetdb::params::puppetdb_initconf,
-           setting => 'JAVA_ARGS',
-           require => Package[$puppetdb_package],
-           notify => Service[$puppetdb_service],
+          $java_args, {
+            ensure            => present,
+            section           => '',
+            key_val_separator => '=',
+            path              => $puppetdb::params::puppetdb_initconf,
+            setting           => 'JAVA_ARGS',
+            require           => Package[$puppetdb_package],
+            notify            => Service[$puppetdb_service],
           }))
     } else {
-      ini_setting {'java_args':
-        ensure => present,
+      ini_setting { 'java_args':
+        ensure  => present,
         section => '',
-        path => $puppetdb::params::puppetdb_initconf,
+        path    => $puppetdb::params::puppetdb_initconf,
         setting => 'JAVA_ARGS',
         require => Package[$puppetdb_package],
-        notify => Service[$puppetdb_service],
-        value => puppetdb_flatten_java_args($java_args),
+        notify  => Service[$puppetdb_service],
+        value   => puppetdb_flatten_java_args($java_args),
       }
     }
   }

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -66,7 +66,7 @@ class puppetdb::server::database (
       $database_suffix = $jdbc_ssl_properties
     }
     elsif $database_ssl {
-      $database_suffix = "?ssl=true"
+      $database_suffix = '?ssl=true'
     }
     else {
       $database_suffix = ''

--- a/manifests/server/global.pp
+++ b/manifests/server/global.pp
@@ -1,12 +1,13 @@
 # PRIVATE CLASS - do not use directly
 class puppetdb::server::global (
-  $vardir = $puppetdb::params::vardir,
+  $vardir  = $puppetdb::params::vardir,
+  $confdir = $puppetdb::params::confdir,
 ) inherits puppetdb::params {
 
   # Set the defaults
   Ini_setting {
-    path => "${confdir}/config.ini",
-    ensure => 'present',
+    path    => "${confdir}/config.ini",
+    ensure  => 'present',
     section => 'global',
     require => File["${confdir}/config.ini"],
   }
@@ -14,7 +15,7 @@ class puppetdb::server::global (
   if $vardir {
     ini_setting { 'puppetdb_global_vardir':
       setting => 'vardir',
-      value => $vardir,
+      value   => $vardir,
     }
   }
 }

--- a/manifests/server/read_database.pp
+++ b/manifests/server/read_database.pp
@@ -66,7 +66,7 @@ class puppetdb::server::read_database (
         $database_suffix = $jdbc_ssl_properties
       }
       elsif $database_ssl {
-        $database_suffix = "?ssl=true"
+        $database_suffix = '?ssl=true'
       }
       else {
         $database_suffix = ''


### PR DESCRIPTION
This patch fixes some of the lint warnings/errors we've been getting on the
forge.

In some cases I've fixed real bugs also, in particular double quotes/single
quotes in cases, which would have broken variable interpolation.

Signed-off-by: Ken Barber <ken@bob.sh>