### PR TITLE
Restrict access to the Puppet master by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,14 @@ The amount of disk space (in MB) to allow for persistent message storage. Defaul
 
 The amount of disk space (in MB) to allow for temporary message storage. Defaults to undef, using the PuppetDB built-in default.
 
+####`certificate_whitelist_file`
+
+The name of the certificate whitelist file to set up and configure in PuppetDB. Defaults to `/etc/puppetdb/certificate-whitelist` or `/etc/puppetlabs/puppetdb/certificate-whitelist` for FOSS and PE respectively.
+
+####`certificate_whitelist`
+
+Array of the X.509 certificate Common Names of clients allowed to connect to PuppetDB. Defaults to empty. Be aware that this permits full access to all Puppet clients to download anything contained in PuppetDB, including the full catalogs of all nodes, which possibly contain sensitive information. Set to `[ $::servername ]` to allow access only from your (single) Puppet master, which is enough for normal operation. Set to a list of Puppet masters if you have multiple.
+
 
 ### puppetdb::server
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,7 +65,9 @@ class puppetdb (
   $max_threads                       = $puppetdb::params::max_threads,
   $command_threads                   = $puppetdb::params::command_threads,
   $store_usage                       = $puppetdb::params::store_usage,
-  $temp_usage                        = $puppetdb::params::temp_usage
+  $temp_usage                        = $puppetdb::params::temp_usage,
+  $certificate_whitelist_file        = $puppetdb::params::certificate_whitelist_file,
+  $certificate_whitelist             = $puppetdb::params::certificate_whitelist,
 ) inherits puppetdb::params {
 
   class { '::puppetdb::server':
@@ -130,6 +132,8 @@ class puppetdb (
     command_threads                   => $command_threads,
     store_usage                       => $store_usage,
     temp_usage                        => $temp_usage,
+    certificate_whitelist_file        => $certificate_whitelist_file,
+    certificate_whitelist             => $certificate_whitelist,
   }
 
   if ($database == 'postgres') {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -70,28 +70,25 @@ class puppetdb::params inherits puppetdb::globals {
   if !($puppetdb_version in ['latest','present','absent']) and versioncmp($puppetdb_version, '3.0.0') < 0 {
     case $::osfamily {
       'RedHat', 'Suse', 'Archlinux','Debian': {
-        $confdir                = '/etc/puppetdb/conf.d'
+        $etcdir                 = '/etc/puppetdb'
         $vardir                 = '/var/lib/puppetdb'
         $database_embedded_path = "${vardir}/db/db"
         $puppet_confdir         = pick($settings::confdir,'/etc/puppet')
         $puppet_service_name    = 'puppetmaster'
-        $ssl_dir                = '/etc/puppetdb/ssl'
       }
       'OpenBSD': {
-        $confdir                = '/etc/puppetdb/conf.d'
+        $etcdir                 = '/etc/puppetdb'
         $vardir                 = '/var/db/puppetdb'
         $database_embedded_path = "${vardir}/db/db"
         $puppet_confdir         = pick($settings::confdir,'/etc/puppet')
         $puppet_service_name    = 'puppetmasterd'
-        $ssl_dir                = '/etc/puppetdb/ssl'
       }
       'FreeBSD': {
-        $confdir                = '/usr/local/etc/puppetdb/conf.d'
+        $etcdir                 = '/usr/local/etc/puppetdb'
         $vardir                 = '/var/db/puppetdb'
         $database_embedded_path = "${vardir}/db/db"
         $puppet_confdir         = pick($settings::confdir,'/usr/local/etc/puppet')
         $puppet_service_name    = 'puppetmaster'
-        $ssl_dir                = '/usr/local/etc/puppetdb/ssl'
       }
       default: {
         fail("The fact 'osfamily' is set to ${::osfamily} which is not supported by the puppetdb module.")
@@ -102,22 +99,19 @@ class puppetdb::params inherits puppetdb::globals {
   } else {
     case $::osfamily {
       'RedHat', 'Suse', 'Archlinux','Debian': {
-        $confdir             = '/etc/puppetlabs/puppetdb/conf.d'
+        $etcdir              = '/etc/puppetlabs/puppetdb'
         $puppet_confdir      = pick($settings::confdir,'/etc/puppetlabs/puppet')
         $puppet_service_name = 'puppetserver'
-        $ssl_dir             = '/etc/puppetlabs/puppetdb/ssl'
       }
       'OpenBSD': {
-        $confdir             = '/etc/puppetlabs/puppetdb/conf.d'
+        $etcdir              = '/etc/puppetlabs/puppetdb'
         $puppet_confdir      = pick($settings::confdir,'/etc/puppetlabs/puppet')
         $puppet_service_name = undef
-        $ssl_dir             = '/etc/puppetlabs/puppetdb/ssl'
       }
       'FreeBSD': {
-        $confdir             = '/usr/local/etc/puppetlabs/puppetdb/conf.d'
+        $etcdir              = '/usr/local/etc/puppetlabs/puppetdb'
         $puppet_confdir      = pick($settings::confdir,'/usr/local/etc/puppetlabs/puppet')
         $puppet_service_name = undef
-        $ssl_dir             = '/usr/local/etc/puppetlabs/puppetdb/ssl'
       }
       default: {
         fail("The fact 'osfamily' is set to ${::osfamily} which is not supported by the puppetdb module.")
@@ -128,6 +122,9 @@ class puppetdb::params inherits puppetdb::globals {
     $vardir                 = '/opt/puppetlabs/server/data/puppetdb'
     $database_embedded_path = "${vardir}/db/db"
   }
+
+  $confdir = "${etcdir}/conf.d"
+  $ssl_dir = "${etcdir}/ssl"
 
   case $::osfamily {
     'RedHat', 'Suse', 'Archlinux': {
@@ -160,4 +157,10 @@ class puppetdb::params inherits puppetdb::globals {
   $ssl_key                  = undef
   $ssl_cert                 = undef
   $ssl_ca_cert              = undef
+
+  $certificate_whitelist_file = "${etcdir}/certificate-whitelist"
+  # the default is free access for now
+  $certificate_whitelist      = [ ]
+  # change to this to only allow access by the puppet master by default:
+  #$certificate_whitelist      = [ $::servername ]
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -61,6 +61,8 @@ class puppetdb::server (
   $command_threads                   = $puppetdb::params::command_threads,
   $store_usage                       = $puppetdb::params::store_usage,
   $temp_usage                        = $puppetdb::params::temp_usage,
+  $certificate_whitelist_file        = $puppetdb::params::certificate_whitelist_file,
+  $certificate_whitelist             = $puppetdb::params::certificate_whitelist,
 ) inherits puppetdb::params {
   # deprecation warnings
   if $database_ssl != undef {
@@ -236,6 +238,13 @@ class puppetdb::server (
     notify             => Service[$puppetdb_service],
   }
 
+  class { 'puppetdb::server::puppetdb':
+    certificate_whitelist_file => $certificate_whitelist_file,
+    certificate_whitelist      => $certificate_whitelist,
+    confdir                    => $confdir,
+    notify                     => Service[$puppetdb_service],
+  }
+
   if !empty($java_args) {
     if $merge_default_java_args {
       create_resources(
@@ -275,6 +284,7 @@ class puppetdb::server (
     Class['puppetdb::server::database'] ->
     Class['puppetdb::server::read_database'] ->
     Class['puppetdb::server::jetty'] ->
+    Class['puppetdb::server::puppetdb'] ->
     Service[$puppetdb_service]
   } else {
     Package[$puppetdb_package] ->
@@ -282,6 +292,7 @@ class puppetdb::server (
     Class['puppetdb::server::database'] ->
     Class['puppetdb::server::read_database'] ->
     Class['puppetdb::server::jetty'] ->
+    Class['puppetdb::server::puppetdb'] ->
     Service[$puppetdb_service]
   }
 }

--- a/manifests/server/puppetdb.pp
+++ b/manifests/server/puppetdb.pp
@@ -1,0 +1,36 @@
+# PRIVATE CLASS - do not use directly
+class puppetdb::server::puppetdb (
+  $certificate_whitelist_file = $puppetdb::params::certificate_whitelist_file,
+  $certificate_whitelist      = $puppetdb::params::certificate_whitelist,
+  $confdir                    = $puppetdb::params::confdir,
+) inherits puppetdb::params {
+
+  # Set the defaults
+  Ini_setting {
+    path    => "${confdir}/puppetdb.ini",
+    ensure  => present,
+    section => 'puppetdb',
+  }
+
+  $certificate_whitelist_setting_ensure = empty($certificate_whitelist) ? {
+    true    => 'absent',
+    default => 'present',
+  }
+
+  # accept connections only from puppet master
+  ini_setting {'puppetdb-connections-from-master-only':
+    ensure  => $certificate_whitelist_setting_ensure,
+    path    => "${confdir}/puppetdb.ini",
+    section => 'puppetdb',
+    setting => 'certificate-whitelist',
+    value   => $certificate_whitelist_file,
+  }
+
+  file { $certificate_whitelist_file:
+    ensure  => $certificate_whitelist_setting_ensure,
+    content => template('puppetdb/certificate-whitelist.erb'),
+    mode    => '0644',
+    owner   => 0,
+    group   => 0,
+  }
+}

--- a/spec/unit/classes/server/puppetdb_ini_spec.rb
+++ b/spec/unit/classes/server/puppetdb_ini_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe 'puppetdb::server::puppetdb', :type => :class do
+  context 'on a supported platform' do
+    let(:facts) do
+      {
+        :osfamily                 => 'RedHat',
+        :fqdn                     => 'test.domain.local',
+      }
+    end
+
+    it { should contain_class('puppetdb::server::puppetdb') }
+
+    describe 'when using default values' do
+      it { should contain_ini_setting('puppetdb-connections-from-master-only').
+        with(
+             'ensure'  => 'absent',
+             'path'    => '/etc/puppetlabs/puppetdb/conf.d/puppetdb.ini',
+             'section' => 'puppetdb',
+             'setting' => 'certificate-whitelist',
+             'value'   => '/etc/puppetlabs/puppetdb/certificate-whitelist'
+             )}
+      it { should contain_file('/etc/puppetlabs/puppetdb/certificate-whitelist').
+        with(
+             'ensure'  => 'absent',
+             'owner'   => 0,
+             'group'   => 0,
+             'mode'    => '0644',
+             'content' => ''
+             )}
+    end
+
+    describe 'when restricting access to puppetdb' do
+      let(:params) do
+        {
+          'certificate_whitelist' => [ 'puppetmaster' ]
+        }
+      end
+      it { should contain_ini_setting('puppetdb-connections-from-master-only').
+        with(
+             'ensure'  => 'present',
+             'path'    => '/etc/puppetlabs/puppetdb/conf.d/puppetdb.ini',
+             'section' => 'puppetdb',
+             'setting' => 'certificate-whitelist',
+             'value'   => '/etc/puppetlabs/puppetdb/certificate-whitelist'
+             )}
+      it { should contain_file('/etc/puppetlabs/puppetdb/certificate-whitelist').
+        with(
+             'ensure'  => 'present',
+             'owner'   => 0,
+             'group'   => 0,
+             'mode'    => '0644',
+             'content' => "puppetmaster\n"
+             )}
+    end
+  end
+end

--- a/templates/certificate-whitelist.erb
+++ b/templates/certificate-whitelist.erb
@@ -1,0 +1,3 @@
+<% @certificate_whitelist.each do |cn| -%>
+<%= cn %>
+<% end -%>


### PR DESCRIPTION
Set up a certificate whitelist file and configure it in PuppetDB so that
only the Puppet master has access by default.