### PR TITLE
Define only Service[puppetmaster]

### DIFF
--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -124,9 +124,11 @@ class puppetdb::master::config (
   if ($restart_puppet) {
     # We will need to restart the puppet master service if certain config
     # files are changed, so here we make sure it's in the catalog.
-    if ! defined(Service[$puppet_service_name]) {
-      service { $puppet_service_name:
-        ensure => running,
+    if $puppet_service_name == 'puppetmaster' {
+        if ! defined(Service[$puppet_service_name]) {
+        service { $puppet_service_name:
+          ensure => running,
+        }
       }
     }
 


### PR DESCRIPTION
Hi, we are using apache and passenger (configured by https://forge.puppetlabs.com/stephenrjohnson/puppet) 

Therefore puppet_service_name is 'httpd' in order to restart the puppet service when puppetdb configuration change. 

This service is managed by module puppetlabs/puppet-apache2 which creates a conflict. 

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Duplicate declaration: Service[httpd] is already declared in file /etc/puppet/environments/prod/modules/puppetdb/manifests/master/config.pp:130; cannot redeclare at /etc/puppet/environments/prod/modules/apache/manifests/service.pp:47 on node puppet.int.prod.gest.kronos
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```
Here is how I fixed it, but if you have any guidance on how it should be done, I'd be glad to help. 

Thanks


