### PR TITLE
(maint) Handle terminus to termini package upgrades

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :development, :test do
-  gem 'rake'
+  # Pinning `rake` because `v11` doesn't support Ruby 1.8.7
+  gem 'rake', '10.5.0'
   gem 'puppetlabs_spec_helper', :require => false
   # Pinning due to bug in newer rspec with Ruby 1.8.7
   gem 'rspec-core', '3.1.7'

--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -44,9 +44,10 @@ class puppetdb::master::config (
   # puppetdb-terminus-3` which is impossible to do via Puppet.
   #
   # This will orphan some old terminus files (from pre-puppet-agent, i.e. puppet
-  # 3.x) that we're orphaned anyways and some of the new terminus files
-  # temporarily. If this exec fails all you need to do is reinstall whatever 2.3
-  # version of the terminus was already installed to revert the change.
+  # 3.x) that are orphaned as part of the Puppet 3 to Puppet 4 upgrade anyways
+  # and some of the new terminus files temporarily. If this exec fails all you
+  # need to do is reinstall whatever 2.3 version of the terminus was already
+  # installed to revert the change.
   if !($puppetdb::params::puppetdb_version in ['present','absent'])
   and versioncmp($puppetdb::params::puppetdb_version, '3.0.0') >= 0
   and $::osfamily in ['RedHat','Suse'] {
@@ -54,6 +55,7 @@ class puppetdb::master::config (
       command => 'rpm -e --justdb puppetdb-terminus',
       path    => '/sbin/:/bin/',
       onlyif  => 'rpm -q puppetdb-terminus',
+      before  => Package[$terminus_package],
     }
   }
 

--- a/spec/unit/classes/master/config_spec.rb
+++ b/spec/unit/classes/master/config_spec.rb
@@ -1,20 +1,21 @@
 require 'spec_helper'
 
 describe 'puppetdb::master::config', :type => :class do
+  basefacts = {
+    :fqdn => 'puppetdb.example.com',
+    :osfamily => 'Debian',
+    :operatingsystem => 'Debian',
+    :operatingsystemrelease => '6.0',
+    :kernel => 'Linux',
+    :lsbdistid => 'Debian',
+    :lsbdistcodename => 'foo',
+    :concat_basedir => '/var/lib/puppet/concat',
+    :id => 'root',
+    :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+  }
 
   let(:facts) do
-    {
-      :fqdn => 'puppetdb.example.com',
-      :osfamily => 'Debian',
-      :operatingsystem => 'Debian',
-      :operatingsystemrelease => '6.0',
-      :kernel => 'Linux',
-      :lsbdistid => 'Debian',
-      :lsbdistcodename => 'foo',
-      :concat_basedir => '/var/lib/puppet/concat',
-      :id => 'root',
-      :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    }
+    basefacts
   end
 
   context 'when PuppetDB on remote server' do
@@ -62,16 +63,31 @@ describe 'puppetdb::master::config', :type => :class do
                     :use_ssl => 'false')}
 
     end
-    
+
     context 'when using default values' do
       it { should contain_package('puppetdb-termini').with( :ensure => 'present' )}
       it { should contain_puppetdb_conn_validator('puppetdb_conn').with(:test_url => '/pdb/meta/v1/version')}
     end
-    
+
     context 'when using an older puppetdb version' do
       let (:pre_condition) { 'class { "puppetdb::globals": version => "2.2.0", }' }
       it { should contain_package('puppetdb-terminus').with( :ensure => '2.2.0' )}
       it { should contain_puppetdb_conn_validator('puppetdb_conn').with(:test_url => '/v3/version')}
+    end
+
+    context 'when upgrading to from v2 to v3 of PuppetDB on RedHat' do
+      let(:facts) do
+        {
+          :osfamily => 'RedHat',
+          :operatingsystem => 'RedHat',
+          :operatingsystemrelease => '7.0',
+          :kernel => 'Linux',
+          :concat_basedir => '/var/lib/puppet/concat',
+        }
+      end
+      let (:pre_condition) { 'class { "puppetdb::globals": version => "3.1.1-1.el7", }' }
+
+      it { should contain_exec('Remove puppetdb-terminus metadata for upgrade').with(:command => 'rpm -e --justdb puppetdb-terminus')}
     end
 
   end

--- a/spec/unit/classes/master/config_spec.rb
+++ b/spec/unit/classes/master/config_spec.rb
@@ -1,21 +1,20 @@
 require 'spec_helper'
 
 describe 'puppetdb::master::config', :type => :class do
-  basefacts = {
-    :fqdn => 'puppetdb.example.com',
-    :osfamily => 'Debian',
-    :operatingsystem => 'Debian',
-    :operatingsystemrelease => '6.0',
-    :kernel => 'Linux',
-    :lsbdistid => 'Debian',
-    :lsbdistcodename => 'foo',
-    :concat_basedir => '/var/lib/puppet/concat',
-    :id => 'root',
-    :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-  }
 
   let(:facts) do
-    basefacts
+    {
+      :fqdn => 'puppetdb.example.com',
+      :osfamily => 'Debian',
+      :operatingsystem => 'Debian',
+      :operatingsystemrelease => '6.0',
+      :kernel => 'Linux',
+      :lsbdistid => 'Debian',
+      :lsbdistcodename => 'foo',
+      :concat_basedir => '/var/lib/puppet/concat',
+      :id => 'root',
+      :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
   end
 
   context 'when PuppetDB on remote server' do


### PR DESCRIPTION
This commit adds an exec to allow users to upgrade to termini-3.x via the
module with no extra manual steps.