### PR TITLE
open_ssl_listen_port defaults to undef, not true

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Defaults to `false`.
 
 ####`open_ssl_listen_port`
 
-If true, open the `ssl_listen_port` on the firewall. Defaults to `true`.
+If true, open the `ssl_listen_port` on the firewall. Defaults to `undef`.
 
 ####`ssl_protocols`
 


### PR DESCRIPTION
changed in commit 448f8bc996b4e797ef463b1c2b89710374d9fd19