### PR TITLE
Update postgresql.pp with postgresql contrib package

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -22,6 +22,8 @@ class puppetdb::database::postgresql(
       listen_addresses        => $listen_addresses,
       port                    => $database_port,
     }
+    # get the pg contrib to use pg_trgm extension
+    class { '::postgresql::server::contrib': }
   }
 
   # create the puppetdb database

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -24,6 +24,9 @@ class puppetdb::database::postgresql(
     }
     # get the pg contrib to use pg_trgm extension
     class { '::postgresql::server::contrib': }
+    postgresql::server::extension { 'pg_trgm':
+      database  => $database_name,
+    }
   }
 
   # create the puppetdb database


### PR DESCRIPTION
postgresql contrib package is needed to avoid warn message about pg_trgm indexes