### PR TITLE
(PDB-2637) Add static facts for selinux and iptables to fix rspec tests

### DIFF
--- a/spec/unit/classes/init_spec.rb
+++ b/spec/unit/classes/init_spec.rb
@@ -15,6 +15,8 @@ describe 'puppetdb', :type => :class do
         :lsbdistcodename => 'foo',
         :id => 'root',
         :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :selinux => false,
+        :iptables_persistent_version => '0.5.7',
       }
     end
 
@@ -31,6 +33,8 @@ describe 'puppetdb', :type => :class do
         :operatingsystemrelease => '6.0',
         :kernel => 'Linux',
         :concat_basedir => '/var/lib/puppet/concat',
+        :selinux => true,
+        :iptables_persistent_version => '0.5.7',
       }
     end
     ttl_args.each do |ttl_arg|

--- a/spec/unit/classes/master/config_spec.rb
+++ b/spec/unit/classes/master/config_spec.rb
@@ -14,6 +14,8 @@ describe 'puppetdb::master::config', :type => :class do
       :concat_basedir => '/var/lib/puppet/concat',
       :id => 'root',
       :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      :selinux => true,
+      :iptables_persistent_version => '0.5.7',
     }
   end
 
@@ -82,6 +84,7 @@ describe 'puppetdb::master::config', :type => :class do
           :operatingsystemrelease => '7.0',
           :kernel => 'Linux',
           :concat_basedir => '/var/lib/puppet/concat',
+          :selinux => true,
         }
       end
       let (:pre_condition) { 'class { "puppetdb::globals": version => "3.1.1-1.el7", }' }

--- a/spec/unit/classes/master/puppetdb_conf_spec.rb
+++ b/spec/unit/classes/master/puppetdb_conf_spec.rb
@@ -14,6 +14,8 @@ describe 'puppetdb::master::puppetdb_conf', :type => :class do
       :concat_basedir => '/var/lib/puppet/concat',
       :id => 'root',
       :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      :selinux => false,
+      :iptables_persistent_version => '0.5.7',
     }
   end
   

--- a/spec/unit/classes/server_spec.rb
+++ b/spec/unit/classes/server_spec.rb
@@ -8,6 +8,7 @@ describe 'puppetdb::server', :type => :class do
         :operatingsystemrelease   => '6.5',
         :fqdn                     => 'test.domain.local',
         :kernel                   => 'Linux',
+        :selinux                  => true,
       }
 
   context 'on a supported platform' do


### PR DESCRIPTION
The firewall module requires selinux and the iptables_persistent_version facts to be defined
up front for our tests to pass. This patch includes those static facts, so we pass.

Signed-off-by: Ken Barber <ken@bob.sh>