### PR TITLE
(PDB-2571) Ensure puppetdb.ini file has correct permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,23 @@
+# Final publish location for module build
 pkg/
+
+# VIM files
 *.swp
+
+# Mac files
 .DS_Store
+
+# Generated directory for coverage results
 coverage/
-spec/fixtures/modules/*
+
+# Gem & bundler related files we do not want persisted to the repository
 Gemfile.lock
 .bundle
 vendor/
-.rspec_system/
+
+# Used by rake spec, for temp modules and other test requirements
+spec/fixtures/
+
+# RVM files that are specific to developers implementation
+.ruby-version
+.ruby-gemset

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -135,6 +135,14 @@ class puppetdb::server (
     }
   }
 
+  class { 'puppetdb::server::global':
+    vardir         => $vardir,
+    confdir        => $confdir,
+    puppetdb_user  => $puppetdb_user,
+    puppetdb_group => $puppetdb_group,
+    notify         => Service[$puppetdb_service],
+  }
+
   class { 'puppetdb::server::command_processing':
     command_threads => $command_threads,
     store_usage     => $store_usage,
@@ -163,6 +171,8 @@ class puppetdb::server (
     conn_keep_alive        => $conn_keep_alive,
     conn_lifetime          => $conn_lifetime,
     confdir                => $confdir,
+    puppetdb_user          => $puppetdb_user,
+    puppetdb_group         => $puppetdb_group,
     notify                 => Service[$puppetdb_service],
   }
 
@@ -181,6 +191,8 @@ class puppetdb::server (
     conn_keep_alive     => $read_conn_keep_alive,
     conn_lifetime       => $read_conn_lifetime,
     confdir             => $confdir,
+    puppetdb_user       => $puppetdb_user,
+    puppetdb_group      => $puppetdb_group,
     notify              => Service[$puppetdb_service],
   }
 
@@ -193,7 +205,7 @@ class puppetdb::server (
 
   if str2bool($ssl_deploy_certs) == true {
     validate_absolute_path($ssl_dir)
-    file{
+    file {
       $ssl_dir:
         ensure  => directory,
         owner   => $puppetdb_user,
@@ -238,12 +250,16 @@ class puppetdb::server (
     confdir            => $confdir,
     max_threads        => $max_threads,
     notify             => Service[$puppetdb_service],
+    puppetdb_user      => $puppetdb_user,
+    puppetdb_group     => $puppetdb_group,
   }
 
   class { 'puppetdb::server::puppetdb':
     certificate_whitelist_file => $certificate_whitelist_file,
     certificate_whitelist      => $certificate_whitelist,
     confdir                    => $confdir,
+    puppetdb_user              => $puppetdb_user,
+    puppetdb_group             => $puppetdb_group,
     notify                     => Service[$puppetdb_service],
   }
 

--- a/manifests/server/command_processing.pp
+++ b/manifests/server/command_processing.pp
@@ -6,12 +6,6 @@ class puppetdb::server::command_processing (
   $confdir         = $puppetdb::params::confdir,
 ) inherits puppetdb::params {
 
-
-  file { "${confdir}/config.ini":
-    ensure => 'present',
-    mode   => '0644',
-  }
-
   # Set the defaults
   Ini_setting {
     path    => "${confdir}/config.ini",

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -19,6 +19,8 @@ class puppetdb::server::database (
   $conn_keep_alive        = $puppetdb::params::conn_keep_alive,
   $conn_lifetime          = $puppetdb::params::conn_lifetime,
   $confdir                = $puppetdb::params::confdir,
+  $puppetdb_user          = $puppetdb::params::puppetdb_user,
+  $puppetdb_group         = $puppetdb::params::puppetdb_group,
 ) inherits puppetdb::params {
 
   if str2bool($database_validate) {
@@ -40,9 +42,17 @@ class puppetdb::server::database (
     }
   }
 
+  file { "${confdir}/database.ini":
+    ensure => file,
+    owner => $puppetdb_user,
+    group => $puppetdb_group,
+    mode => '0600',
+  }
+
+  $file_require = File["${confdir}/database.ini"]
   $ini_setting_require = str2bool($database_validate) ? {
-    false => undef,
-    default  => Class['puppetdb::server::validate_db'],
+    false => $file_require,
+    default  => [$file_require, Class['puppetdb::server::validate_db']],
   }
   # Set the defaults
   Ini_setting {

--- a/manifests/server/global.pp
+++ b/manifests/server/global.pp
@@ -1,8 +1,17 @@
 # PRIVATE CLASS - do not use directly
 class puppetdb::server::global (
-  $vardir  = $puppetdb::params::vardir,
-  $confdir = $puppetdb::params::confdir,
+  $vardir         = $puppetdb::params::vardir,
+  $confdir        = $puppetdb::params::confdir,
+  $puppetdb_user  = $puppetdb::params::puppetdb_user,
+  $puppetdb_group = $puppetdb::params::puppetdb_group,
 ) inherits puppetdb::params {
+
+  file { "${confdir}/config.ini":
+    ensure => file,
+    owner => $puppetdb_user,
+    group => $puppetdb_group,
+    mode => '0600',
+  }
 
   # Set the defaults
   Ini_setting {

--- a/manifests/server/jetty.pp
+++ b/manifests/server/jetty.pp
@@ -13,13 +13,23 @@ class puppetdb::server::jetty (
   $ssl_protocols      = $puppetdb::params::ssl_protocols,
   $confdir            = $puppetdb::params::confdir,
   $max_threads        = $puppetdb::params::max_threads,
+  $puppetdb_user      = $puppetdb::params::puppetdb_user,
+  $puppetdb_group     = $puppetdb::params::puppetdb_group,
 ) inherits puppetdb::params {
+
+  file { "${confdir}/jetty.ini":
+    ensure => file,
+    owner => $puppetdb_user,
+    group => $puppetdb_group,
+    mode => '0600',
+  }
 
   # Set the defaults
   Ini_setting {
     path    => "${confdir}/jetty.ini",
     ensure  => present,
     section => 'jetty',
+    require => File["${confdir}/puppetdb.ini"],
   }
 
   $cleartext_setting_ensure = $disable_cleartext ? {

--- a/manifests/server/puppetdb.pp
+++ b/manifests/server/puppetdb.pp
@@ -3,13 +3,23 @@ class puppetdb::server::puppetdb (
   $certificate_whitelist_file = $puppetdb::params::certificate_whitelist_file,
   $certificate_whitelist      = $puppetdb::params::certificate_whitelist,
   $confdir                    = $puppetdb::params::confdir,
+  $puppetdb_user              = $puppetdb::params::puppetdb_user,
+  $puppetdb_group             = $puppetdb::params::puppetdb_group,
 ) inherits puppetdb::params {
+
+  file { "${confdir}/puppetdb.ini":
+    ensure => file,
+    owner => $puppetdb_user,
+    group => $puppetdb_group,
+    mode => '0600',
+  }
 
   # Set the defaults
   Ini_setting {
     path    => "${confdir}/puppetdb.ini",
     ensure  => present,
     section => 'puppetdb',
+    require => File["${confdir}/puppetdb.ini"],
   }
 
   $certificate_whitelist_setting_ensure = empty($certificate_whitelist) ? {

--- a/manifests/server/read_database.pp
+++ b/manifests/server/read_database.pp
@@ -43,12 +43,13 @@ class puppetdb::server::read_database (
       ensure => file,
       owner  => $puppetdb_user,
       group  => $puppetdb_group,
-      mode   => '0600';
+      mode   => '0600',
     }
 
+    $file_require = File["${confdir}/read_database.ini"]
     $ini_setting_require = str2bool($database_validate) ? {
-      false => undef,
-      default  => Class['puppetdb::server::validate_read_db'],
+      false   => $file_require,
+      default => [$file_require, Class['puppetdb::server::validate_read_db']],
     }
     # Set the defaults
     Ini_setting {
@@ -74,13 +75,13 @@ class puppetdb::server::read_database (
 
       $subname = "//${database_host}:${database_port}/${database_name}${database_suffix}"
 
-      ini_setting { 'puppetdb_read_psdatabase_username':
+      ini_setting { 'puppetdb_read_database_username':
         setting => 'username',
         value   => $database_username,
       }
 
       if $database_password != undef {
-        ini_setting { 'puppetdb_read_psdatabase_password':
+        ini_setting { 'puppetdb_read_database_password':
           setting => 'password',
           value   => $database_password,
         }

--- a/spec/unit/classes/init_spec.rb
+++ b/spec/unit/classes/init_spec.rb
@@ -22,6 +22,8 @@ describe 'puppetdb', :type => :class do
 
     describe 'when using default values for puppetdb class' do
       it { should contain_class('puppetdb') }
+      it { should contain_class('puppetdb::server') }
+      it { should contain_class('puppetdb::database::postgresql') }
     end
   end
 

--- a/spec/unit/classes/server/database_ini_spec.rb
+++ b/spec/unit/classes/server/database_ini_spec.rb
@@ -14,6 +14,13 @@ describe 'puppetdb::server::database', :type => :class do
     it { should contain_class('puppetdb::server::database') }
 
     describe 'when using default values' do
+      it { should contain_file('/etc/puppetlabs/puppetdb/conf.d/database.ini').
+        with(
+             'ensure'  => 'file',
+             'owner'   => 'puppetdb',
+             'group'   => 'puppetdb',
+             'mode'    => '0600'
+             )}
       it { should contain_ini_setting('puppetdb_psdatabase_username').
         with(
              'ensure'  => 'present',

--- a/spec/unit/classes/server/global_ini_spec.rb
+++ b/spec/unit/classes/server/global_ini_spec.rb
@@ -21,7 +21,13 @@ describe 'puppetdb::server::global', :type => :class do
           'setting' => 'vardir',
           'value' => '/opt/puppetlabs/server/data/puppetdb'
       )}
-
+      it { should contain_file('/etc/puppetlabs/puppetdb/conf.d/config.ini').
+        with(
+             'ensure'  => 'file',
+             'owner'   => 'puppetdb',
+             'group'   => 'puppetdb',
+             'mode'    => '0600'
+      )}
     end
 
     describe 'when using a legacy puppetdb version' do

--- a/spec/unit/classes/server/jetty_ini_spec.rb
+++ b/spec/unit/classes/server/jetty_ini_spec.rb
@@ -12,6 +12,13 @@ describe 'puppetdb::server::jetty', :type => :class do
     it { should contain_class('puppetdb::server::jetty') }
 
     describe 'when using default values' do
+      it { should contain_file('/etc/puppetlabs/puppetdb/conf.d/jetty.ini').
+        with(
+             'ensure'  => 'file',
+             'owner'   => 'puppetdb',
+             'group'   => 'puppetdb',
+             'mode'    => '0600'
+             )}
       it { should contain_ini_setting('puppetdb_host').
         with(
              'ensure'  => 'present',

--- a/spec/unit/classes/server/puppetdb_ini_spec.rb
+++ b/spec/unit/classes/server/puppetdb_ini_spec.rb
@@ -28,6 +28,13 @@ describe 'puppetdb::server::puppetdb', :type => :class do
              'mode'    => '0644',
              'content' => ''
              )}
+      it { should contain_file('/etc/puppetlabs/puppetdb/conf.d/puppetdb.ini').
+        with(
+             'ensure'  => 'file',
+             'owner'   => 'puppetdb',
+             'group'   => 'puppetdb',
+             'mode'    => '0600'
+             )}
     end
 
     describe 'when restricting access to puppetdb' do

--- a/spec/unit/classes/server/read_database_ini_spec.rb
+++ b/spec/unit/classes/server/read_database_ini_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+
+describe 'puppetdb::server::read_database', :type => :class do
+  context 'on a supported platform' do
+    let(:facts) do
+      {
+        :osfamily                 => 'RedHat',
+        :operatingsystem          => 'RedHat',
+        :operatingsystemrelease   => '7.0',
+        :fqdn                     => 'test.domain.local',
+      }
+    end
+
+    it { should contain_class('puppetdb::server::read_database') }
+
+    describe 'when using default values' do
+      it { should contain_file('/etc/puppetlabs/puppetdb/conf.d/read_database.ini').with('ensure' => 'absent') }
+    end
+
+    describe 'when using minimum working values' do
+      let(:params) do
+        {
+          'database_host' => 'puppetdb'
+        }
+      end
+      it { should contain_file('/etc/puppetlabs/puppetdb/conf.d/read_database.ini').
+        with(
+             'ensure'  => 'file',
+             'owner'   => 'puppetdb',
+             'group'   => 'puppetdb',
+             'mode'    => '0600'
+             )}
+      it { should contain_ini_setting('puppetdb_read_database_username').
+        with(
+             'ensure'  => 'present',
+             'path'    => '/etc/puppetlabs/puppetdb/conf.d/read_database.ini',
+             'section' => 'read-database',
+             'setting' => 'username',
+             'value'   => 'puppetdb'
+             )}
+      it { should contain_ini_setting('puppetdb_read_database_password').
+        with(
+             'ensure'  => 'present',
+             'path'    => '/etc/puppetlabs/puppetdb/conf.d/read_database.ini',
+             'section' => 'read-database',
+             'setting' => 'password',
+             'value'   => 'puppetdb'
+             )}
+      it { should contain_ini_setting('puppetdb_read_classname').
+        with(
+             'ensure'  => 'present',
+             'path'    => '/etc/puppetlabs/puppetdb/conf.d/read_database.ini',
+             'section' => 'read-database',
+             'setting' => 'classname',
+             'value'   => 'org.postgresql.Driver'
+             )}
+      it { should contain_ini_setting('puppetdb_read_subprotocol').
+        with(
+             'ensure'  => 'present',
+             'path'    => '/etc/puppetlabs/puppetdb/conf.d/read_database.ini',
+             'section' => 'read-database',
+             'setting' => 'subprotocol',
+             'value'   => 'postgresql'
+             )}
+      it { should contain_ini_setting('puppetdb_read_subname').
+        with(
+             'ensure'  => 'present',
+             'path'    => '/etc/puppetlabs/puppetdb/conf.d/read_database.ini',
+             'section' => 'read-database',
+             'setting' => 'subname',
+             'value'   => '//puppetdb:5432/puppetdb'
+             )}
+      it { should contain_ini_setting('puppetdb_read_log_slow_statements').
+        with(
+             'ensure'  => 'present',
+             'path'    => '/etc/puppetlabs/puppetdb/conf.d/read_database.ini',
+             'section' => 'read-database',
+             'setting' => 'log-slow-statements',
+             'value'   => 10
+             )}
+      it { should contain_ini_setting('puppetdb_read_conn_max_age').
+        with(
+             'ensure'  => 'present',
+             'path'    => '/etc/puppetlabs/puppetdb/conf.d/read_database.ini',
+             'section' => 'read-database',
+             'setting' => 'conn-max-age',
+             'value'   => '60'
+             )}
+      it { should contain_ini_setting('puppetdb_read_conn_keep_alive').
+        with(
+             'ensure'  => 'present',
+             'path'    => '/etc/puppetlabs/puppetdb/conf.d/read_database.ini',
+             'section' => 'read-database',
+             'setting' => 'conn-keep-alive',
+             'value'   => '45'
+             )}
+      it { should contain_ini_setting('puppetdb_read_conn_lifetime').
+        with(
+             'ensure'  => 'present',
+             'path'    => '/etc/puppetlabs/puppetdb/conf.d/read_database.ini',
+             'section' => 'read-database',
+             'setting' => 'conn-lifetime',
+             'value'   => '0'
+             )}
+    end
+  end
+end

--- a/spec/unit/classes/server_spec.rb
+++ b/spec/unit/classes/server_spec.rb
@@ -16,7 +16,15 @@ describe 'puppetdb::server', :type => :class do
       basefacts
     end
 
-    it { should contain_class('puppetdb::server') }
+    describe 'when using default values' do
+      it { should contain_class('puppetdb::server') }
+      it { should contain_class('puppetdb::server::global') }
+      it { should contain_class('puppetdb::server::command_processing') }
+      it { should contain_class('puppetdb::server::database') }
+      it { should contain_class('puppetdb::server::read_database') }
+      it { should contain_class('puppetdb::server::jetty') }
+      it { should contain_class('puppetdb::server::puppetdb') }
+    end
 
     describe 'when not specifying JAVA_ARGS' do
       it { should_not contain_ini_subsetting('Xms') }


### PR DESCRIPTION
Much like read-database.ini, we need to ensure the permissions for puppetdb.ini are set explicitly
to ensure permissions are still correct after configuration. Without this users with different umask
settings may find their files are no longer accessible after the module runs.

Signed-off-by: Ken Barber <ken@bob.sh>