### PR TITLE
Add a manage_db parameter to let the user the freedom to manage

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,11 @@ Specify the supported SSL protocols for PuppetDB (e.g. TLSv1, TLSv1.1, TLSv1.2.)
 
 If true, the PostgreSQL server will be managed by this module. Defaults to `true`.
 
+###`manage_db`
+
+If true, the PostgreSQL database in the PostgreSQL instance will be managed by
+this module. Defaults to `true`.
+
 ####`database`
 
 Which database backend to use; legal values are `postgres` (default) or

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -7,6 +7,7 @@ class puppetdb::database::postgresql(
   $database_password    = $puppetdb::params::database_password,
   $database_port        = $puppetdb::params::database_port,
   $manage_server        = $puppetdb::params::manage_dbserver,
+  $manage_db            = $puppetdb::params::manage_db,
   $manage_package_repo  = $puppetdb::params::manage_pg_repo,
   $postgres_version     = $puppetdb::params::postgres_version,
 ) inherits puppetdb::params {
@@ -30,9 +31,11 @@ class puppetdb::database::postgresql(
   }
 
   # create the puppetdb database
-  postgresql::server::db { $database_name:
-    user     => $database_username,
-    password => $database_password,
-    grant    => 'all',
+  if $manage_db {
+    postgresql::server::db { $database_name:
+      user     => $database_username,
+      password => $database_password,
+      grant    => 'all',
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,7 @@ class puppetdb (
   $ssl_ca_cert                       = $puppetdb::params::ssl_ca_cert,
   $ssl_protocols                     = $puppetdb::params::ssl_protocols,
   $manage_dbserver                   = $puppetdb::params::manage_dbserver,
+  $manage_db                         = $puppetdb::params::manage_db,
   $manage_package_repo               = $puppetdb::params::manage_pg_repo,
   $postgres_version                  = $puppetdb::params::postgres_version,
   $database                          = $puppetdb::params::database,
@@ -155,6 +156,7 @@ class puppetdb (
       database_password   => $database_password,
       database_port       => $database_port,
       manage_server       => $manage_dbserver,
+      manage_db           => $manage_db,
       manage_package_repo => $manage_package_repo,
       postgres_version    => $postgres_version,
       before              => $database_before

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,7 @@ class puppetdb::params inherits puppetdb::globals {
   $puppetdb_version          = $puppetdb::globals::version
   $database                  = $puppetdb::globals::database
   $manage_dbserver           = true
+  $manage_db                 = true
   $manage_pg_repo            = true
   $postgres_version          = '9.4'
 


### PR DESCRIPTION
the postgresql database creation outside of the puppetdb module.

An other option would be to include the functionality within the
manage_dbserver parameter, if set to false/true, instead of introducing
another parameter.

Let me know if you would be in favor of the manage_dbserver parameter
takes care of it, and I change it, or if you prefer, what I did so far.

Then I can change if necessary, and add some tests for it.

cheers,
