### PR TITLE
FIX: Unbreak on OpenBSD

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -64,8 +64,6 @@ class puppetdb::params inherits puppetdb::globals {
 
   $puppetdb_package     = 'puppetdb'
   $puppetdb_service     = 'puppetdb'
-  $puppetdb_user        = 'puppetdb'
-  $puppetdb_group       = 'puppetdb'
   $masterless           = false
 
   if !($puppetdb_version in ['latest','present','absent']) and versioncmp($puppetdb_version, '3.0.0') < 0 {
@@ -129,12 +127,23 @@ class puppetdb::params inherits puppetdb::globals {
 
   case $::osfamily {
     'RedHat', 'Suse', 'Archlinux': {
+      $puppetdb_user     = 'puppetdb'
+      $puppetdb_group    = 'puppetdb'
       $puppetdb_initconf = '/etc/sysconfig/puppetdb'
     }
     'Debian': {
+      $puppetdb_user     = 'puppetdb'
+      $puppetdb_group    = 'puppetdb'
       $puppetdb_initconf = '/etc/default/puppetdb'
     }
-    'OpenBSD','FreeBSD': {
+    'OpenBSD': {
+      $puppetdb_user     = '_puppetdb'
+      $puppetdb_group    = '_puppetdb'
+      $puppetdb_initconf = undef
+    }
+    'FreeBSD': {
+      $puppetdb_user     = 'puppetdb'
+      $puppetdb_group    = 'puppetdb'
       $puppetdb_initconf = undef
     }
     default: {


### PR DESCRIPTION
Seems since end of April/beginning of May, with the
permission changes of puppetdb config ini files,
it is broken on OpenBSD.
This fixes is by setting the $puppetdb_user, and
$puppetdb_group in OS specific case statements:

Some more info:

underprivileged users from packages start with
_underscore, as well as such groups, therefore on OpenBSD, the
user:group is _puppetdb:_puppetdb

Because of that, instead of the single default in params.pp,
move the definition of puppetdb_user and puppetdb_group into
one of the OS specific case statement.

As a side node not 100% related:
I wonder why the config files have to be owned by
the puppetdb user/group?

From a security point of view, wouldn't it make more sense,
to have the config files owned by root:$puppetdb_group, and
permissions like 640? IIRC, puppetdb doesn't need to fiddle
with the files, only read access should be fine?

puppetdb is java, so the JIT requires memory regions being
writable AND executable at the same time, so being a potentially
valuable target for attackers.

cheers,
Sebastian