### PR TITLE
replace invalid node name variables in 3-node example

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,14 @@ scenario might look like:
     $master_host = 'master.example.lan'
     $puppetdb_host = 'puppetdb.example.lan'
     $postgres_host = 'postgres.example.lan'
-    node $master_host {
+    node 'master.example.lan' {
       # Here we configure the Puppet master to use PuppetDB,
       # telling it the hostname of the PuppetDB node
       class { 'puppetdb::master::config':
         puppetdb_server => $puppetdb_host,
       }
     }
-    node $postgres_host {
+    node 'postgres.example.lan' {
       # Here we install and configure PostgreSQL and the PuppetDB
       # database instance, and tell PostgreSQL that it should
       # listen for connections to the `$postgres_host`
@@ -121,7 +121,7 @@ scenario might look like:
         listen_addresses => $postgres_host,
       }
     }
-    node $puppetdb_host {
+    node 'puppetdb.example.lan' {
       # Here we install and configure PuppetDB, and tell it where to
       # find the PostgreSQL database.
       class { 'puppetdb::server':


### PR DESCRIPTION
The basic 3-node setup example in the documentation assigns some variables for the 3 nodes and then tries to resolve these variables in the node statements. However, puppet complains of a syntax error when it reaches the variable just after the `node` keyword.

`puppet parser validate` also indicates that code is not valid.

The puppet language reference says...
>A node statement’s name must be one of the following:
>    A quoted string containing only letters, numbers, underscores (_), hyphens (-), and periods (.).
>    A regular expression.
>    The bare word default.

Newbies (like I am) reading the examples might get confused (like I did). :-)
