### PR TITLE
(PDB-3032) add puppetversion fact in spec tests

### DIFF
--- a/spec/unit/classes/init_spec.rb
+++ b/spec/unit/classes/init_spec.rb
@@ -7,6 +7,7 @@ describe 'puppetdb', :type => :class do
     let(:facts) do
       {
         :osfamily => 'Debian',
+        :puppetversion => Puppet.version,
         :operatingsystem => 'Debian',
         :operatingsystemrelease => '6.0',
         :kernel => 'Linux',
@@ -32,6 +33,7 @@ describe 'puppetdb', :type => :class do
       {
         :osfamily => 'RedHat',
         :operatingsystem => 'Debian',
+        :puppetversion => Puppet.version,
         :operatingsystemrelease => '6.0',
         :kernel => 'Linux',
         :concat_basedir => '/var/lib/puppet/concat',

--- a/spec/unit/classes/master/config_spec.rb
+++ b/spec/unit/classes/master/config_spec.rb
@@ -6,6 +6,7 @@ describe 'puppetdb::master::config', :type => :class do
     {
       :fqdn => 'puppetdb.example.com',
       :osfamily => 'Debian',
+      :puppetversion => Puppet.version,
       :operatingsystem => 'Debian',
       :operatingsystemrelease => '6.0',
       :kernel => 'Linux',
@@ -81,6 +82,7 @@ describe 'puppetdb::master::config', :type => :class do
         {
           :osfamily => 'RedHat',
           :operatingsystem => 'RedHat',
+          :puppetversion => Puppet.version,
           :operatingsystemrelease => '7.0',
           :kernel => 'Linux',
           :concat_basedir => '/var/lib/puppet/concat',

--- a/spec/unit/classes/master/puppetdb_conf_spec.rb
+++ b/spec/unit/classes/master/puppetdb_conf_spec.rb
@@ -7,6 +7,7 @@ describe 'puppetdb::master::puppetdb_conf', :type => :class do
       :fqdn => 'puppetdb.example.com',
       :osfamily => 'Debian',
       :operatingsystem => 'Debian',
+      :puppetversion => Puppet.version,
       :operatingsystemrelease => '6.0',
       :lsbdistid => 'Debian',
       :lsbdistcodename => 'foo',

--- a/spec/unit/classes/master/report_processor_spec.rb
+++ b/spec/unit/classes/master/report_processor_spec.rb
@@ -5,6 +5,7 @@ describe 'puppetdb::master::report_processor', :type => :class do
     let(:facts) do
       {
           :osfamily                 => 'RedHat',
+          :puppetversion            => Puppet.version,
           :clientcert               => 'test.domain.local',
       }
     end

--- a/spec/unit/classes/server/command_processing_spec.rb
+++ b/spec/unit/classes/server/command_processing_spec.rb
@@ -4,7 +4,8 @@ describe 'puppetdb::server::command_processing', :type => :class do
   context 'on a supported platform' do
     let(:facts) do
       {
-        :osfamily                 => 'OpenBSD',
+        :osfamily => 'OpenBSD',
+        :puppetversion => Puppet.version,
       }
     end
 

--- a/spec/unit/classes/server/database_ini_spec.rb
+++ b/spec/unit/classes/server/database_ini_spec.rb
@@ -6,6 +6,7 @@ describe 'puppetdb::server::database', :type => :class do
       {
         :osfamily                 => 'RedHat',
         :operatingsystem          => 'RedHat',
+        :puppetversion            => Puppet.version,
         :operatingsystemrelease   => '7.0',
         :fqdn                     => 'test.domain.local',
       }

--- a/spec/unit/classes/server/read_database_ini_spec.rb
+++ b/spec/unit/classes/server/read_database_ini_spec.rb
@@ -6,6 +6,7 @@ describe 'puppetdb::server::read_database', :type => :class do
       {
         :osfamily                 => 'RedHat',
         :operatingsystem          => 'RedHat',
+        :puppetversion            => Puppet.version,
         :operatingsystemrelease   => '7.0',
         :fqdn                     => 'test.domain.local',
       }

--- a/spec/unit/classes/server_spec.rb
+++ b/spec/unit/classes/server_spec.rb
@@ -6,6 +6,7 @@ describe 'puppetdb::server', :type => :class do
         :osfamily                 => 'RedHat',
         :operatingsystem          => 'RedHat',
         :operatingsystemrelease   => '6.5',
+        :puppetversion            => Puppet.version,
         :fqdn                     => 'test.domain.local',
         :kernel                   => 'Linux',
         :selinux                  => true,


### PR DESCRIPTION
A recent change in puppetlabs-apt requires us to set this explicitly to avoid a
lookup error.