### PR TITLE
Add support for multiple puppetdb servers

### DIFF
--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -12,6 +12,7 @@ class puppetdb::master::config (
     true    => $::puppetdb::disable_ssl,
     default => false,
   },
+  $puppetdb_servers            = [],
   $masterless                  = $puppetdb::params::masterless,
   $puppetdb_soft_write_failure = false,
   $manage_routes               = true,
@@ -156,6 +157,7 @@ class puppetdb::master::config (
     class { 'puppetdb::master::puppetdb_conf':
       server             => $puppetdb_server,
       port               => $puppetdb_port,
+      servers            => $puppetdb_servers,
       soft_write_failure => $puppetdb_soft_write_failure,
       puppet_confdir     => $puppet_confdir,
       legacy_terminus    => $puppetdb::params::terminus_package == 'puppetdb-terminus',

--- a/manifests/master/puppetdb_conf.pp
+++ b/manifests/master/puppetdb_conf.pp
@@ -3,6 +3,7 @@
 class puppetdb::master::puppetdb_conf (
   $server             = 'localhost',
   $port               = '8081',
+  $servers            = [],
   $soft_write_failure = $puppetdb::disable_ssl ? {
     true => true,
     default => false,
@@ -30,9 +31,16 @@ class puppetdb::master::puppetdb_conf (
       value   => $port,
     }
   } else {
-    ini_setting { 'puppetdbserver_urls':
-      setting => 'server_urls',
-      value   => "https://${server}:${port}/",
+    unless $servers {
+      ini_setting { 'puppetdbserver_urls':
+        setting => 'server_urls',
+        value   => "https://${server}:${port}/",
+      }
+    } else {
+      ini_setting {'puppetdbserver_urls':
+        setting => 'server_urls',
+        value   => join($servers, ',')
+      }
     }
   }
 

--- a/spec/unit/classes/master/config_spec.rb
+++ b/spec/unit/classes/master/config_spec.rb
@@ -28,6 +28,11 @@ describe 'puppetdb::master::config', :type => :class do
 
   end
 
+  context 'when PuppetDB has more than one server' do
+    let (:params) {{ :puppetdb_servers => ["https://puppetdb1.mycompany.com:8081/", "https://puppetdb2.mycompany.com:8081/"] }}
+    it { should contain_ini_setting('puppetdbserver_urls').with_value("https://puppetdb1.mycompany.com:8081/,https://puppetdb2.mycompany.com:8081/") }
+  end
+
   context 'when PuppetDB and Puppet Master are on the same server' do
 
     context 'when using default values' do


### PR DESCRIPTION
Simple change to allow a comma delimited list of puppetdb servers to choose from.
