### PR TITLE
Add postgres_datadir to params

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -9,12 +9,14 @@ class puppetdb::database::postgresql(
   $manage_server        = $puppetdb::params::manage_dbserver,
   $manage_package_repo  = $puppetdb::params::manage_pg_repo,
   $postgres_version     = $puppetdb::params::postgres_version,
+  $postgres_datadir     = $puppetdb::params::postgres_datadir,
 ) inherits puppetdb::params {
 
   if $manage_server {
     class { '::postgresql::globals':
       manage_package_repo => $manage_package_repo,
       version             => $postgres_version,
+      datadir             => $postgres_datadir,
     }
     # get the pg server up and running
     class { '::postgresql::server':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,8 +12,7 @@ class puppetdb::params inherits puppetdb::globals {
   $disable_ssl               = false
   $open_ssl_listen_port      = undef
   $postgres_listen_addresses = 'localhost'
-  $postgres_datadir          = '/var/lib/postgresql/9.4/main'
-
+  
   $puppetdb_version          = $puppetdb::globals::version
   $database                  = $puppetdb::globals::database
   $manage_dbserver           = true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class puppetdb::params inherits puppetdb::globals {
   $disable_ssl               = false
   $open_ssl_listen_port      = undef
   $postgres_listen_addresses = 'localhost'
+  $postgres_datadir          = '/var/lib/postgresql/9.4/main'
 
   $puppetdb_version          = $puppetdb::globals::version
   $database                  = $puppetdb::globals::database


### PR DESCRIPTION
This modification allow change postgresql data_directory.
Example from nodes.pp:

```
node puppet-db {
  class { 'puppetdb::database::postgresql':
    listen_addresses => '0.0.0.0',
    postgres_datadir => '/media/data/postgresql/9.4/main',
  }
}
```
