### PR TITLE
Add support for Ruby 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.1
+  - 2.3.1
 env:
   matrix:
   - PUPPET_GEM_VERSION="~> 3.7.1"
@@ -25,5 +26,13 @@ matrix:
   exclude:
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 4"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.7.1"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.7"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3" PARSER="future"
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,8 @@ group :development, :test do
   gem 'rspec-core', '3.1.7'
   gem 'rspec-puppet', '~> 2.0'
   gem 'puppet-lint',  '~> 1.1'
-  gem 'metadata-json-lint'
+  gem 'metadata-json-lint', '0.0.11' if RUBY_VERSION < '1.9'
+  gem 'metadata-json-lint'           if RUBY_VERSION >= '1.9'
   gem 'json_pure', '~> 1.8'
 end
 


### PR DESCRIPTION
The Puppet AIO is going to start using ruby 2.3.1 and as such needs to
be supported here.