### PR TITLE
module always requires a local postgresql

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -27,12 +27,12 @@ class puppetdb::database::postgresql(
     postgresql::server::extension { 'pg_trgm':
       database  => $database_name,
     }
-  }
-
-  # create the puppetdb database
-  postgresql::server::db { $database_name:
-    user     => $database_username,
-    password => $database_password,
-    grant    => 'all',
+  
+    # create the puppetdb database
+    postgresql::server::db { $database_name:
+      user     => $database_username,
+      password => $database_password,
+      grant    => 'all',
+    }
   }
 }


### PR DESCRIPTION
Currently this module still requires a local postgresql server even when connecting to a remote one. As it always tries to manage a local postgresql db, this change fixes that problem.