### PR TITLE
Fix duplicate resource errors for puppet service due to parse order

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,6 +767,14 @@ If `true`, the module will store values from `puppetdb_server` and `puppetdb_por
 parameters in the PuppetDB configuration file. If `false`, an existing PuppetDB
 configuration file will be used to retrieve server and port values.
 
+####`create_puppet_service_resource`
+
+If `true`, AND if `restart_puppet` is true, then the module will create a service
+resource for `puppet_service_name` if it has not been defined. Defaults to `true`.
+If you are already declaring the `puppet_service_name` service resource in another
+part of your code, setting this to `false` will avoid creation of that service
+resource by this module, avoiding potential duplicate resource errors.
+
 ####`strict_validation`
 
 If `true`, the module will fail if PuppetDB is not reachable, otherwise it will

--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -18,6 +18,7 @@ class puppetdb::master::config (
   $manage_storeconfigs         = true,
   $manage_report_processor     = false,
   $manage_config               = true,
+  $create_puppet_service_resource = true,
   $strict_validation           = true,
   $enable_reports              = false,
   $puppet_confdir              = $puppetdb::params::puppet_confdir,
@@ -165,8 +166,12 @@ class puppetdb::master::config (
 
   if ($restart_puppet) {
     # We will need to restart the puppet master service if certain config
-    # files are changed, so here we make sure it's in the catalog.
-    if ! defined(Service[$puppet_service_name]) {
+    # files are changed, so here we make sure it's in the catalog. This is
+    # parse-order dependent and could prevent another part of the code from
+    # declaring the service, so set $create_puppet_service_resource to false if you
+    # are absolutely sure you're declaring Service[$puppet_service_name] in
+    # some other way.
+    if $create_puppet_service_resource and ! defined(Service[$puppet_service_name]) {
       service { $puppet_service_name:
         ensure => running,
       }

--- a/spec/unit/classes/master/config_spec.rb
+++ b/spec/unit/classes/master/config_spec.rb
@@ -96,4 +96,47 @@ describe 'puppetdb::master::config', :type => :class do
 
   end
 
+  context 'when restart_puppet is true' do
+    let(:pre_condition) { 'class { "puppetdb": }' }
+
+    context 'with create_puppet_service_resource as default' do
+      let(:params) do
+        {
+          :puppet_service_name            => 'puppetserver',
+          :restart_puppet                 => true,
+        }
+      end
+
+      it { should contain_service('puppetserver').with(:ensure => 'running') }
+    end
+
+    context 'with create_puppet_service_resource = true' do
+      let(:params) do
+        {
+          :create_puppet_service_resource => true,
+          :puppet_service_name            => 'puppetserver',
+          :restart_puppet                 => true,
+        }
+      end
+
+      it { should contain_service('puppetserver').with(:ensure => 'running') }
+    end
+
+    context 'with create_puppet_service_resource = false' do
+      # Also setting the various parameters that notify the service to be false. Otherwise this error surfaces:
+      # `Could not find resource 'Service[puppetserver]' for relationship from 'Class[Puppetdb::Master::Puppetdb_conf]'`
+      let(:params) do
+        {
+          :create_puppet_service_resource => false,
+          :manage_config                  => false,
+          :manage_report_processor        => false,
+          :manage_routes                  => false,
+          :puppet_service_name            => 'puppetserver',
+          :restart_puppet                 => true,
+        }
+      end
+
+      it { should_not contain_service('puppetserver') }
+    end
+  end
 end


### PR DESCRIPTION
The `defined(Service[$puppet_service_name])` pattern in this module is parse-order dependent, and I was unable to declare a `service { 'puppetserver' ...}` in some code I was writing because this module was parsed first and had already declared the resource.

To work around this, I've added a parameter to the class, which defaults to the existing behavior of `true` so it won't break existing behavior for anyone. However, one can override this to `false` which skips the creation of the `$puppet_service_name` service resource in this module and thereby avoids a duplicate resource error when compiling the catalog.