### PR TITLE
(PDB-3587) Add puppetlabs-postgresql 5.x support and integrate rspec-puppetfacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ spec/fixtures/
 # RVM files that are specific to developers implementation
 .ruby-version
 .ruby-gemset
+
+# Add Jetbrains RubyMine .idea folder
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ spec/fixtures/
 
 # Add Jetbrains RubyMine .idea folder
 .idea/
+
+# Beaker files
+log/
+.vagrant/
+junit/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,31 @@
 ---
+sudo: false
 language: ruby
-bundler_args: --without system_tests
-script: "bundle exec metadata-json-lint --strict-license --fail-on-warnings metadata.json && bundle exec rake spec SPEC_OPTS='--format documentation'"
-after_success:
-  - git clone -q git://github.com/puppetlabs/ghpublisher.git .forge-release
-  - .forge-release/publish
-rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
-  - 2.1.1
-  - 2.3.1
-env:
-  matrix:
-  - PUPPET_GEM_VERSION="~> 3.7.1"
-  - PUPPET_GEM_VERSION="~> 3.7"
-  - PUPPET_GEM_VERSION="~> 3"
-  - PUPPET_GEM_VERSION="~> 3" PARSER="future"
-  - PUPPET_GEM_VERSION="~> 4"
-  global:
-  - PUBLISHER_LOGIN=puppetlabs
-  -  secure: "FInoEwh3G4Auqp+OOdIc20lDLqrV6FHzWsM8ercHWjhDRD23VI49B1qqehWjaI8lKM3D5mTvdup23IVQBJo8M0rR/yfju1NhMYFTQ5bcJIrbQ3fn4n/zSaE8gLTOtHwzjSlqTJAYjxOAnp1VdMZngqpU/RYfSk68zJD34NqfovA="
+cache: bundler
+script: "bundle exec rake release_checks"
+#Inserting below due to the following issue: https://github.com/travis-ci/travis-ci/issues/3531#issuecomment-88311203
+before_install:
+  - gem update bundler
 matrix:
   fast_finish: true
-  exclude:
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.7.1"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.7"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3" PARSER="future"
+  include:
+  - rvm: 2.3.1
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/ubuntu-14.04
+    script: bundle exec rake beaker
+    services: docker
+    sudo: required
+  - rvm: 2.3.1
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-7
+    script: bundle exec rake beaker
+    services: docker
+    sudo: required
+  - rvm: 2.3.1
+    bundler_args: --without system_tests
+    env: PUPPET_GEM_VERSION="~> 4.0"
+  - rvm: 2.1.7
+    bundler_args: --without system_tests
+    env: PUPPET_GEM_VERSION="~> 4.0"
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -11,13 +11,15 @@ group :development, :test do
   gem 'puppet-lint',  '~> 1.1'
   gem 'metadata-json-lint', '0.0.11' if RUBY_VERSION < '1.9'
   gem 'metadata-json-lint'           if RUBY_VERSION >= '1.9'
-  gem 'json_pure', '~> 1.8'
+  gem 'json', '~> 1.8'
 end
 
 group :system_tests do
-  gem 'beaker',                :require => false
-  gem 'beaker-rspec',          :require => false
-  gem 'serverspec',            :require => false
+  gem 'beaker',                       :require => false
+  gem 'beaker-rspec',                 :require => false
+  gem 'beaker-puppet_install_helper', :require => false
+  gem 'beaker-module_install_helper', :require => false
+  gem 'serverspec',                   :require => false
 end
 
 if puppetversion = ENV['PUPPET_GEM_VERSION']

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ group :development, :test do
   # Pinning due to bug in newer rspec with Ruby 1.8.7
   gem 'rspec-core', '3.1.7'
   gem 'rspec-puppet', '~> 2.0'
+  gem 'rspec-puppet-facts'
   gem 'puppet-lint',  '~> 1.1'
   gem 'metadata-json-lint', '0.0.11' if RUBY_VERSION < '1.9'
   gem 'metadata-json-lint'           if RUBY_VERSION >= '1.9'

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -20,7 +20,7 @@ class puppetdb::database::postgresql(
     class { '::postgresql::server':
       ip_mask_allow_all_users => '0.0.0.0/0',
       listen_addresses        => $listen_addresses,
-      port                    => 0 + $database_port,
+      port                    => scanf($database_port, '%i')[0],
     }
     # get the pg contrib to use pg_trgm extension
     class { '::postgresql::server::contrib': }

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -20,7 +20,7 @@ class puppetdb::database::postgresql(
     class { '::postgresql::server':
       ip_mask_allow_all_users => '0.0.0.0/0',
       listen_addresses        => $listen_addresses,
-      port                    => $database_port,
+      port                    => 0 + $database_port,
     }
     # get the pg contrib to use pg_trgm extension
     class { '::postgresql::server::contrib': }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,7 +18,7 @@ class puppetdb::params inherits puppetdb::globals {
   $database                  = $puppetdb::globals::database
   $manage_dbserver           = true
 
-  if $::osfamily =~ /Redhat|Debian/ {
+  if $::osfamily =~ /RedHat|Debian/ {
     $manage_pg_repo            = true
   } else {
     $manage_pg_repo            = false

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,7 +17,12 @@ class puppetdb::params inherits puppetdb::globals {
   $puppetdb_version          = $puppetdb::globals::version
   $database                  = $puppetdb::globals::database
   $manage_dbserver           = true
-  $manage_pg_repo            = true
+
+  if $osfamily =~ /Redhat|Debian/ {
+    $manage_pg_repo            = true
+  } else {
+    $manage_pg_repo            = false
+  }
   $postgres_version          = '9.4'
 
   # The remaining database settings are not used for an embedded database

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,7 +27,7 @@ class puppetdb::params inherits puppetdb::globals {
 
   # The remaining database settings are not used for an embedded database
   $database_host          = 'localhost'
-  $database_port          = 5432
+  $database_port          = '5432'
   $database_name          = 'puppetdb'
   $database_username      = 'puppetdb'
   $database_password      = 'puppetdb'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@ class puppetdb::params inherits puppetdb::globals {
 
   # The remaining database settings are not used for an embedded database
   $database_host          = 'localhost'
-  $database_port          = '5432'
+  $database_port          = 5432
   $database_name          = 'puppetdb'
   $database_username      = 'puppetdb'
   $database_password      = 'puppetdb'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,7 +18,7 @@ class puppetdb::params inherits puppetdb::globals {
   $database                  = $puppetdb::globals::database
   $manage_dbserver           = true
 
-  if $osfamily =~ /Redhat|Debian/ {
+  if $::osfamily =~ /Redhat|Debian/ {
     $manage_pg_repo            = true
   } else {
     $manage_pg_repo            = false

--- a/metadata.json
+++ b/metadata.json
@@ -78,7 +78,7 @@
         },
         {
             "name": "puppetlabs/postgresql",
-            "version_requirement": ">= 4.0.0 <5.0.0"
+            "version_requirement": ">= 4.0.0 < 6.0.0"
         },
         {
             "name": "puppetlabs/firewall",

--- a/metadata.json
+++ b/metadata.json
@@ -87,6 +87,10 @@
         {
             "name": "puppetlabs/stdlib",
             "version_requirement": ">= 4.2.2 <5.0.0"
+        },
+        {
+            "name": "puppetlabs/ntp",
+            "version_requirement": ">= 5.0.0 < 7.0.0"
         }
     ]
 }

--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper_acceptance'
 describe 'basic tests:' do
   it 'make sure we have copied the module across' do
     # No point diagnosing any more if the module wasn't copied properly
-    shell("ls /etc/puppet/modules/puppetdb") do |r|
+    shell("ls /etc/puppetlabs/code/modules/puppetdb") do |r|
       r.exit_code.should == 0
-      r.stdout.should =~ /Modulefile/
+      r.stdout.should =~ /metadata\.json/
       r.stderr.should == ''
     end
   end
@@ -13,7 +13,7 @@ describe 'basic tests:' do
   describe 'single node setup' do
     pp = <<-EOS
       # Single node setup
-      class { 'ntp': panic => false } ->
+      class { 'ntp': panic => undef } ->
       class { 'puppetdb': disable_ssl => true, } ->
       class { 'puppetdb::master::config': puppetdb_port => '8080', puppetdb_server => 'localhost' }
     EOS
@@ -26,7 +26,7 @@ describe 'basic tests:' do
 
   describe 'enabling report processor' do
     pp = <<-EOS
-      class { 'ntp': panic => false } ->
+      class { 'ntp': panic => undef } ->
       class { 'puppetdb': disable_ssl => true, } ->
       class { 'puppetdb::master::config':
         puppetdb_port => '8080',
@@ -40,7 +40,7 @@ describe 'basic tests:' do
       apply_manifest(pp, :catch_errors  => true)
       apply_manifest(pp, :catch_changes => true)
 
-      shell('cat /etc/puppet/puppet.conf') do |r|
+      shell('cat /etc/puppetlabs/puppet/puppet.conf') do |r|
         expect(r.stdout).to match(/^reports\s*=\s*([^,]+,)*puppetdb(,[^,]+)*$/)
       end
     end

--- a/spec/acceptance/nodesets/docker/centos-7.yml
+++ b/spec/acceptance/nodesets/docker/centos-7.yml
@@ -1,0 +1,13 @@
+---
+HOSTS:
+  centos-7-x64:
+    platform: el-7-x86_64
+    hypervisor: docker
+    image: centos:7
+    docker_preserve_image: true
+    docker_cmd: '["/usr/sbin/init"]'
+    # install various tools required to get the image up to usable levels
+    docker_image_commands:
+      - 'yum install -y crontabs tar wget openssl sysvinit-tools iproute which initscripts'
+CONFIG:
+  trace_limit: 200

--- a/spec/acceptance/nodesets/docker/debian-8.yml
+++ b/spec/acceptance/nodesets/docker/debian-8.yml
@@ -1,0 +1,12 @@
+---
+HOSTS:
+  debian-8-x64:
+    platform: debian-8-amd64
+    hypervisor: docker
+    image: debian:8
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'apt-get update && apt-get install -y net-tools wget locales strace lsof && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen'
+CONFIG:
+  trace_limit: 200

--- a/spec/acceptance/nodesets/docker/ubuntu-14.04.yml
+++ b/spec/acceptance/nodesets/docker/ubuntu-14.04.yml
@@ -1,0 +1,15 @@
+---
+HOSTS:
+  ubuntu-1404-x64:
+    roles:
+      - master
+    platform: ubuntu-14.04-amd64
+    hypervisor: docker
+    image: ubuntu:14.04
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      # ensure that upstart is booting correctly in the container
+      - 'rm /usr/sbin/policy-rc.d && rm /sbin/initctl && dpkg-divert --rename --remove /sbin/initctl && apt-get update && apt-get install -y net-tools wget && locale-gen en_US.UTF-8'
+CONFIG:
+  trace_limit: 200

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -1,0 +1,3 @@
+---
+concat_basedir: '/var/lib/puppet/concat'
+iptables_persistent_version: '0.5.7'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-facts'
+include RspecPuppetFacts
 
 RSpec.configure do |c|
   # Utilize RspecPuppetFacts instead of hand mocking them

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,15 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
 
 RSpec.configure do |c|
+  # Utilize RspecPuppetFacts instead of hand mocking them
+  default_facts = {
+      puppetversion: Puppet.version,
+      facterversion: Facter.version
+  }
+  default_facts.merge!(YAML.load(File.read(File.expand_path('../default_facts.yml', __FILE__)))) if File.exist?(File.expand_path('../default_facts.yml', __FILE__))
+  default_facts.merge!(YAML.load(File.read(File.expand_path('../default_module_facts.yml', __FILE__)))) if File.exist?(File.expand_path('../default_module_facts.yml', __FILE__))
+  c.default_facts = default_facts
+
   c.include PuppetlabsSpec::Files
 
   c.before :each do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,47 +1,44 @@
-require 'beaker-rspec/spec_helper'
-require 'beaker-rspec/helpers/serverspec'
+require 'beaker-rspec'
+require 'beaker/puppet_install_helper'
+require 'beaker/module_install_helper'
 
 hosts.each do |host|
   if host['platform'] =~ /debian/
     on host, 'echo \'export PATH=/var/lib/gems/1.8/bin/:${PATH}\' >> ~/.bashrc'
   end
   #install_puppet
-  if host['platform'] =~ /el-(5|6)/
+  if host['platform'] =~ /el-(5|6|7)/
     relver = $1
-    on host, "rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-#{relver}.noarch.rpm"
-    on host, 'yum install -y puppet puppet-server'
+    on host, "rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-pc1-el-#{relver}.noarch.rpm"
+    on host, 'yum install -y puppetserver'
   elsif host['platform'] =~ /fedora-(\d+)/
     relver = $1
-    on host, "rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-fedora-#{relver}.noarch.rpm"
-    on host, 'yum install -y puppet-server'
+    on host, "rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-pc1-fedora-#{relver}.noarch.rpm"
+    on host, 'yum install -y puppetserver'
   elsif host['platform'] =~ /(ubuntu|debian)/
     if ! host.check_for_package 'curl'
       on host, 'apt-get install -y curl'
     end
-    on host, 'curl -O http://apt.puppetlabs.com/puppetlabs-release-$(lsb_release -c -s).deb'
-    on host, 'dpkg -i puppetlabs-release-$(lsb_release -c -s).deb'
-    on host, 'apt-get -y -f -m update'
-    on host, 'apt-get install -y puppet puppetmaster'
+    on host, 'curl -O http://apt.puppetlabs.com/puppetlabs-release-pc1-$(lsb_release -c -s).deb'
+    on host, 'dpkg -i puppetlabs-release-pc1-$(lsb_release -c -s).deb'
+    on host, 'apt-get -y -m update'
+    on host, 'apt-get install -y puppetserver'
   else
     raise "install_puppet() called for unsupported platform '#{host['platform']}' on '#{host.name}'"
   end
 end
 
-RSpec.configure do |c|
-  # Project root
-  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
+install_ca_certs unless ENV['PUPPET_INSTALL_TYPE'] =~ %r{pe}i
+install_module_on(hosts)
+install_module_dependencies_on(hosts)
 
+RSpec.configure do |c|
   # Readable test descriptions
   c.formatter = :documentation
-
-  # Configure all nodes in nodeset
-  c.before :suite do
-    hosts.each do |host|
-    # Install module and dependencies
-      copy_module_to(host, :source => proj_root, :module_name => 'puppetdb')
-      on host, puppet('module', 'install', 'puppetlabs-ntp'), { :acceptable_exit_codes => [0,1] }
-      on host, puppet('module', 'install', 'puppetlabs-postgresql', '--version', '">= 3.1.0 <4.0.0"'), { :acceptable_exit_codes => [0,1] }
-      on host, puppet('module', 'install', 'puppetlabs-inifile', '--version', '1.x'), { :acceptable_exit_codes => [0,1] }
+  hosts.each do |host|
+    if host[:platform] =~ %r{el-7-x86_64} && host[:hypervisor] =~ %r{docker}
+      on(host, "sed -i '/nodocs/d' /etc/yum.conf")
     end
   end
 end

--- a/spec/unit/classes/init_spec.rb
+++ b/spec/unit/classes/init_spec.rb
@@ -7,8 +7,7 @@ describe 'puppetdb', :type => :class do
     context "on #{os}" do
       let(:facts) do
         facts.merge({
-          :selinux => false,
-          :iptables_persistent_version => '0.5.7'
+          :selinux => false
         })
       end
 

--- a/spec/unit/classes/init_spec.rb
+++ b/spec/unit/classes/init_spec.rb
@@ -3,28 +3,20 @@ require 'spec_helper'
 describe 'puppetdb', :type => :class do
   ttl_args = ['node_ttl','node_purge_ttl','report_ttl']
 
-  context 'on a supported platform' do
-    let(:facts) do
-      {
-        :osfamily => 'Debian',
-        :puppetversion => Puppet.version,
-        :operatingsystem => 'Debian',
-        :operatingsystemrelease => '6.0',
-        :kernel => 'Linux',
-        :concat_basedir => '/var/lib/puppet/concat',
-        :lsbdistid => 'Debian',
-        :lsbdistcodename => 'foo',
-        :id => 'root',
-        :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        :selinux => false,
-        :iptables_persistent_version => '0.5.7',
-      }
-    end
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge({
+          :selinux => false,
+          :iptables_persistent_version => '0.5.7'
+        })
+      end
 
-    describe 'when using default values for puppetdb class' do
-      it { should contain_class('puppetdb') }
-      it { should contain_class('puppetdb::server') }
-      it { should contain_class('puppetdb::database::postgresql') }
+      describe 'when using default values for puppetdb class' do
+        it { should contain_class('puppetdb') }
+        it { should contain_class('puppetdb::server') }
+        it { should contain_class('puppetdb::database::postgresql') }
+      end
     end
   end
 

--- a/spec/unit/classes/master/config_spec.rb
+++ b/spec/unit/classes/master/config_spec.rb
@@ -1,99 +1,93 @@
 require 'spec_helper'
 
 describe 'puppetdb::master::config', :type => :class do
-
-  let(:facts) do
-    {
-      :fqdn => 'puppetdb.example.com',
-      :osfamily => 'Debian',
-      :puppetversion => Puppet.version,
-      :operatingsystem => 'Debian',
-      :operatingsystemrelease => '6.0',
-      :kernel => 'Linux',
-      :lsbdistid => 'Debian',
-      :lsbdistcodename => 'foo',
-      :concat_basedir => '/var/lib/puppet/concat',
-      :id => 'root',
-      :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-      :selinux => true,
-      :iptables_persistent_version => '0.5.7',
-    }
-  end
-
-  context 'when PuppetDB on remote server' do
-
-    context 'when using default values' do
-      it { should compile.with_all_deps }
-    end
-
-  end
-
-  context 'when PuppetDB and Puppet Master are on the same server' do
-
-    context 'when using default values' do
-      let(:pre_condition) { 'class { "puppetdb": }' }
-
-      it { should contain_puppetdb_conn_validator('puppetdb_conn').with(
-                    :puppetdb_server => 'puppetdb.example.com',
-                    :puppetdb_port => '8081',
-                    :use_ssl => 'true') }
-    end
-
-    context 'when puppetdb class is declared with disable_ssl => true' do
-      let(:pre_condition) { 'class { "puppetdb": disable_ssl => true }' }
-
-      it { should contain_puppetdb_conn_validator('puppetdb_conn').with(
-                    :puppetdb_port => '8080',
-                    :use_ssl => 'false')}
-    end
-
-    context 'when puppetdb_port => 1234' do
-      let(:pre_condition) { 'class { "puppetdb": }' }
-      let(:params) do { :puppetdb_port => '1234' } end
-
-      it { should contain_puppetdb_conn_validator('puppetdb_conn').with(
-                    :puppetdb_port => '1234',
-                    :use_ssl => 'true')}
-    end
-
-    context 'when puppetdb_port => 1234 AND the puppetdb class is declared with disable_ssl => true' do
-      let(:pre_condition) { 'class { "puppetdb": disable_ssl => true }' }
-      let(:params) do {:puppetdb_port => '1234'} end
-
-      it { should contain_puppetdb_conn_validator('puppetdb_conn').with(
-                    :puppetdb_port => '1234',
-                    :use_ssl => 'false')}
-
-    end
-
-    context 'when using default values' do
-      it { should contain_package('puppetdb-termini').with( :ensure => 'present' )}
-      it { should contain_puppetdb_conn_validator('puppetdb_conn').with(:test_url => '/pdb/meta/v1/version')}
-    end
-
-    context 'when using an older puppetdb version' do
-      let (:pre_condition) { 'class { "puppetdb::globals": version => "2.2.0", }' }
-      it { should contain_package('puppetdb-terminus').with( :ensure => '2.2.0' )}
-      it { should contain_puppetdb_conn_validator('puppetdb_conn').with(:test_url => '/v3/version')}
-    end
-
-    context 'when upgrading to from v2 to v3 of PuppetDB on RedHat' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
       let(:facts) do
-        {
-          :osfamily => 'RedHat',
-          :operatingsystem => 'RedHat',
-          :puppetversion => Puppet.version,
-          :operatingsystemrelease => '7.0',
-          :kernel => 'Linux',
-          :concat_basedir => '/var/lib/puppet/concat',
-          :selinux => true,
-        }
+        facts.merge({
+            :puppetversion => Puppet.version,
+            :fqdn => 'puppetdb.example.com',
+            :selinux => true,
+            :iptables_persistent_version => '0.5.7',
+        })
       end
-      let (:pre_condition) { 'class { "puppetdb::globals": version => "3.1.1-1.el7", }' }
 
-      it { should contain_exec('Remove puppetdb-terminus metadata for upgrade').with(:command => 'rpm -e --justdb puppetdb-terminus')}
+      context 'when PuppetDB on remote server' do
+
+        context 'when using default values' do
+          it { should compile.with_all_deps }
+        end
+
+      end
+
+      context 'when PuppetDB and Puppet Master are on the same server' do
+
+        context 'when using default values' do
+          let(:pre_condition) { 'class { "puppetdb": }' }
+
+          it { should contain_puppetdb_conn_validator('puppetdb_conn').with(
+              :puppetdb_server => 'puppetdb.example.com',
+              :puppetdb_port => '8081',
+              :use_ssl => 'true') }
+        end
+
+        context 'when puppetdb class is declared with disable_ssl => true' do
+          let(:pre_condition) { 'class { "puppetdb": disable_ssl => true }' }
+
+          it { should contain_puppetdb_conn_validator('puppetdb_conn').with(
+              :puppetdb_port => '8080',
+              :use_ssl => 'false')}
+        end
+
+        context 'when puppetdb_port => 1234' do
+          let(:pre_condition) { 'class { "puppetdb": }' }
+          let(:params) do { :puppetdb_port => '1234' } end
+
+          it { should contain_puppetdb_conn_validator('puppetdb_conn').with(
+              :puppetdb_port => '1234',
+              :use_ssl => 'true')}
+        end
+
+        context 'when puppetdb_port => 1234 AND the puppetdb class is declared with disable_ssl => true' do
+          let(:pre_condition) { 'class { "puppetdb": disable_ssl => true }' }
+          let(:params) do {:puppetdb_port => '1234'} end
+
+          it { should contain_puppetdb_conn_validator('puppetdb_conn').with(
+              :puppetdb_port => '1234',
+              :use_ssl => 'false')}
+
+        end
+
+        context 'when using default values' do
+          it { should contain_package('puppetdb-termini').with( :ensure => 'present' )}
+          it { should contain_puppetdb_conn_validator('puppetdb_conn').with(:test_url => '/pdb/meta/v1/version')}
+        end
+
+        context 'when using an older puppetdb version' do
+          let (:pre_condition) { 'class { "puppetdb::globals": version => "2.2.0", }' }
+          it { should contain_package('puppetdb-terminus').with( :ensure => '2.2.0' )}
+          it { should contain_puppetdb_conn_validator('puppetdb_conn').with(:test_url => '/v3/version')}
+        end
+
+        context 'when upgrading to from v2 to v3 of PuppetDB on RedHat' do
+          let(:facts) do
+            {
+                :osfamily => 'RedHat',
+                :operatingsystem => 'RedHat',
+                :puppetversion => Puppet.version,
+                :operatingsystemrelease => '7.0',
+                :kernel => 'Linux',
+                :concat_basedir => '/var/lib/puppet/concat',
+                :selinux => true,
+            }
+          end
+          let (:pre_condition) { 'class { "puppetdb::globals": version => "3.1.1-1.el7", }' }
+
+          it { should contain_exec('Remove puppetdb-terminus metadata for upgrade').with(:command => 'rpm -e --justdb puppetdb-terminus')}
+        end
+
+      end
+
     end
-
   end
-
 end

--- a/spec/unit/classes/master/config_spec.rb
+++ b/spec/unit/classes/master/config_spec.rb
@@ -7,8 +7,7 @@ describe 'puppetdb::master::config', :type => :class do
         facts.merge({
             :puppetversion => Puppet.version,
             :fqdn => 'puppetdb.example.com',
-            :selinux => true,
-            :iptables_persistent_version => '0.5.7',
+            :selinux => true
         })
       end
 
@@ -54,8 +53,8 @@ describe 'puppetdb::master::config', :type => :class do
 
           it { should contain_puppetdb_conn_validator('puppetdb_conn').with(
               :puppetdb_port => '1234',
-              :use_ssl => 'false')}
-
+              :use_ssl => 'false'
+          ) }
         end
 
         context 'when using default values' do
@@ -69,25 +68,23 @@ describe 'puppetdb::master::config', :type => :class do
           it { should contain_puppetdb_conn_validator('puppetdb_conn').with(:test_url => '/v3/version')}
         end
 
-        context 'when upgrading to from v2 to v3 of PuppetDB on RedHat' do
-          let(:facts) do
-            {
-                :osfamily => 'RedHat',
-                :operatingsystem => 'RedHat',
-                :puppetversion => Puppet.version,
-                :operatingsystemrelease => '7.0',
-                :kernel => 'Linux',
-                :concat_basedir => '/var/lib/puppet/concat',
-                :selinux => true,
-            }
-          end
-          let (:pre_condition) { 'class { "puppetdb::globals": version => "3.1.1-1.el7", }' }
-
-          it { should contain_exec('Remove puppetdb-terminus metadata for upgrade').with(:command => 'rpm -e --justdb puppetdb-terminus')}
-        end
-
       end
 
     end
+  end
+  context 'when upgrading to from v2 to v3 of PuppetDB on RedHat' do
+    let(:facts) do
+      {
+          :osfamily => 'RedHat',
+          :operatingsystem => 'RedHat',
+          :puppetversion => Puppet.version,
+          :operatingsystemrelease => '7.0',
+          :kernel => 'Linux',
+          :selinux => true,
+      }
+    end
+    let (:pre_condition) { 'class { "puppetdb::globals": version => "3.1.1-1.el7", }' }
+
+    it { should contain_exec('Remove puppetdb-terminus metadata for upgrade').with(:command => 'rpm -e --justdb puppetdb-terminus')}
   end
 end

--- a/spec/unit/classes/master/puppetdb_conf_spec.rb
+++ b/spec/unit/classes/master/puppetdb_conf_spec.rb
@@ -1,14 +1,15 @@
 require 'spec_helper'
 
 describe 'puppetdb::master::puppetdb_conf', :type => :class do
+  let :node do
+    'puppetdb.example.com'
+  end
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do
         facts.merge({
-            :fqdn => 'puppetdb.example.com',
             :puppetversion => Puppet.version,
-            :selinux => false,
-            :iptables_persistent_version => '0.5.7',
+            :selinux => false
         })
 
       end

--- a/spec/unit/classes/master/puppetdb_conf_spec.rb
+++ b/spec/unit/classes/master/puppetdb_conf_spec.rb
@@ -1,35 +1,30 @@
 require 'spec_helper'
 
 describe 'puppetdb::master::puppetdb_conf', :type => :class do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge({
+            :fqdn => 'puppetdb.example.com',
+            :puppetversion => Puppet.version,
+            :selinux => false,
+            :iptables_persistent_version => '0.5.7',
+        })
 
-  let(:facts) do
-    {
-      :fqdn => 'puppetdb.example.com',
-      :osfamily => 'Debian',
-      :operatingsystem => 'Debian',
-      :puppetversion => Puppet.version,
-      :operatingsystemrelease => '6.0',
-      :lsbdistid => 'Debian',
-      :lsbdistcodename => 'foo',
-      :kernel => 'Linux',
-      :concat_basedir => '/var/lib/puppet/concat',
-      :id => 'root',
-      :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-      :selinux => false,
-      :iptables_persistent_version => '0.5.7',
-    }
+      end
+
+      let(:pre_condition) { 'class { "puppetdb": }' }
+
+      context 'when using using default values' do
+        it { should contain_ini_setting('puppetdbserver_urls').with( :value => 'https://localhost:8081/' )}
+      end
+
+      context 'when using using default values' do
+        let (:params) do { :legacy_terminus => true, } end
+        it { should contain_ini_setting('puppetdbserver').with( :value => 'localhost' )}
+        it { should contain_ini_setting('puppetdbport').with( :value => '8081' )}
+      end
+
+    end
   end
-  
-  let(:pre_condition) { 'class { "puppetdb": }' }
-  
-  context 'when using using default values' do
-    it { should contain_ini_setting('puppetdbserver_urls').with( :value => 'https://localhost:8081/' )}
-  end
-  
-  context 'when using using default values' do
-    let (:params) do { :legacy_terminus => true, } end
-    it { should contain_ini_setting('puppetdbserver').with( :value => 'localhost' )}
-    it { should contain_ini_setting('puppetdbport').with( :value => '8081' )}
-  end
-  
 end

--- a/spec/unit/classes/master/report_processor_spec.rb
+++ b/spec/unit/classes/master/report_processor_spec.rb
@@ -1,45 +1,46 @@
 require 'spec_helper'
 
 describe 'puppetdb::master::report_processor', :type => :class do
-  context 'on a supported platform' do
-    let(:facts) do
-      {
-          :osfamily                 => 'RedHat',
-          :puppetversion            => Puppet.version,
-          :clientcert               => 'test.domain.local',
-      }
-    end
-
-    it { should contain_class('puppetdb::master::report_processor') }
-
-    describe 'when using default values' do
-      it { should contain_ini_subsetting('puppet.conf/reports/puppetdb').
-        with(
-        'ensure'                => 'absent',
-        'path'                  => '/etc/puppet/puppet.conf',
-        'section'               => 'master',
-        'setting'               => 'reports',
-        'subsetting'            => 'puppetdb',
-        'subsetting_separator'  => ','
-        )}
-    end
-
-    describe 'when enabling reports' do
-      let(:params) do
-        {
-            'enable' => true
-        }
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge({
+            :puppetversion            => Puppet.version,
+            :clientcert               => 'test.domain.local',
+        })
       end
 
-      it { should contain_ini_subsetting('puppet.conf/reports/puppetdb').
-          with(
-          'ensure'                => 'present',
-          'path'                  => '/etc/puppet/puppet.conf',
-          'section'               => 'master',
-          'setting'               => 'reports',
-          'subsetting'            => 'puppetdb',
-          'subsetting_separator'  => ','
-      )}
+      it { should contain_class('puppetdb::master::report_processor') }
+
+      describe 'when using default values' do
+        it { should contain_ini_subsetting('puppet.conf/reports/puppetdb').
+            with(
+                'ensure'                => 'absent',
+                'path'                  => '/etc/puppet/puppet.conf',
+                'section'               => 'master',
+                'setting'               => 'reports',
+                'subsetting'            => 'puppetdb',
+                'subsetting_separator'  => ','
+            )}
+      end
+
+      describe 'when enabling reports' do
+        let(:params) do
+          {
+              'enable' => true
+          }
+        end
+
+        it { should contain_ini_subsetting('puppet.conf/reports/puppetdb').
+            with(
+                'ensure'                => 'present',
+                'path'                  => '/etc/puppet/puppet.conf',
+                'section'               => 'master',
+                'setting'               => 'reports',
+                'subsetting'            => 'puppetdb',
+                'subsetting_separator'  => ','
+            )}
+      end
     end
   end
 end

--- a/spec/unit/classes/server_spec.rb
+++ b/spec/unit/classes/server_spec.rb
@@ -1,14 +1,15 @@
 require 'spec_helper'
 
 describe 'puppetdb::server', :type => :class do
+  let :node do
+    'test.domain.local'
+  end
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do
         facts.merge({
             :puppetversion => Puppet.version,
-            :fqdn => 'test.domain.local',
-            :selinux => true,
-            :iptables_persistent_version => '0.5.7',
+            :selinux => true
         })
       end
 

--- a/spec/unit/classes/server_spec.rb
+++ b/spec/unit/classes/server_spec.rb
@@ -1,77 +1,80 @@
 require 'spec_helper'
 
 describe 'puppetdb::server', :type => :class do
-  basefacts =
-      {
-        :osfamily                 => 'RedHat',
-        :operatingsystem          => 'RedHat',
-        :operatingsystemrelease   => '6.5',
-        :puppetversion            => Puppet.version,
-        :fqdn                     => 'test.domain.local',
-        :kernel                   => 'Linux',
-        :selinux                  => true,
-      }
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge({
+            :puppetversion => Puppet.version,
+            :fqdn => 'test.domain.local',
+            :selinux => true,
+            :iptables_persistent_version => '0.5.7',
+        })
+      end
 
-  context 'on a supported platform' do
-    let(:facts) do
-      basefacts
-    end
+      case facts[:osfamily]
+      when 'Debian'
+        pathdir = '/etc/default/puppetdb'
+      else
+        pathdir = '/etc/sysconfig/puppetdb'
+      end
 
-    describe 'when using default values' do
-      it { should contain_class('puppetdb::server') }
-      it { should contain_class('puppetdb::server::global') }
-      it { should contain_class('puppetdb::server::command_processing') }
-      it { should contain_class('puppetdb::server::database') }
-      it { should contain_class('puppetdb::server::read_database') }
-      it { should contain_class('puppetdb::server::jetty') }
-      it { should contain_class('puppetdb::server::puppetdb') }
-    end
+      describe 'when using default values' do
+        it { should contain_class('puppetdb::server') }
+        it { should contain_class('puppetdb::server::global') }
+        it { should contain_class('puppetdb::server::command_processing') }
+        it { should contain_class('puppetdb::server::database') }
+        it { should contain_class('puppetdb::server::read_database') }
+        it { should contain_class('puppetdb::server::jetty') }
+        it { should contain_class('puppetdb::server::puppetdb') }
+      end
 
-    describe 'when not specifying JAVA_ARGS' do
-      it { should_not contain_ini_subsetting('Xms') }
-    end
+      describe 'when not specifying JAVA_ARGS' do
+        it { should_not contain_ini_subsetting('Xms') }
+      end
 
-    describe 'when specifying JAVA_ARGS' do
-      let(:params) do
-        {
-          'java_args' => {
-            '-Xms' => '2g',
+      describe 'when specifying JAVA_ARGS' do
+        let(:params) do
+          {
+              'java_args' => {
+                  '-Xms' => '2g',
+              }
           }
-        }
+        end
+
+        context 'on redhat PuppetDB' do
+          it { should contain_ini_subsetting("'-Xms'").
+              with(
+                  'ensure'            => 'present',
+                  'path'              => "#{pathdir}",
+                  'section'           => '',
+                  'key_val_separator' => '=',
+                  'setting'           => 'JAVA_ARGS',
+                  'subsetting'        => '-Xms',
+                  'value'             => '2g'
+              )}
+        end
+
       end
 
-      context 'on standard PuppetDB' do
-        it { should contain_ini_subsetting("'-Xms'").
-        with(
-          'ensure'            => 'present',
-          'path'              => '/etc/sysconfig/puppetdb',
-          'section'           => '',
-          'key_val_separator' => '=',
-          'setting'           => 'JAVA_ARGS',
-          'subsetting'        => '-Xms',
-          'value'             => '2g'
-        )}
-      end
+      describe 'when specifying JAVA_ARGS with merge_default_java_args false' do
+        let (:params) do
+          {
+              'java_args' => {'-Xms' => '2g'},
+              'merge_default_java_args' => false,
+          }
+        end
 
-    end
-
-    describe 'when specifying JAVA_ARGS with merge_default_java_args false' do
-      let (:params) do
-        {
-          'java_args' => {'-Xms' => '2g'},
-          'merge_default_java_args' => false,
-        }
-      end
-
-      context 'on standard PuppetDB' do
-        it { should contain_ini_setting('java_args').
-          with(
-            'ensure' => 'present',
-            'path' => '/etc/sysconfig/puppetdb',
-            'section' => '',
-            'setting' => 'JAVA_ARGS',
-            'value' => '"-Xms2g"'
-        )}
+        context 'on standard PuppetDB' do
+          it { should contain_ini_setting('java_args').
+              with(
+                  'ensure' => 'present',
+                  'path' => "#{pathdir}",
+                  'section' => '',
+                  'setting' => 'JAVA_ARGS',
+                  'value' => '"-Xms2g"'
+              )}
+        end
       end
     end
   end


### PR DESCRIPTION
Casts `$database_port` in `postgresql.pp` to an integer to make module compatible with `puppetlabs-postgresql` 5.x

Fix an issue where `puppetlabs-puppetdb` would pass `true` to `managed_pg_repo` by default for all supported OSes, however `puppetlabs-postgresql` can only manage the pg repo if the `osfamily` is RedHat or Debian.

Added rspec-puppet-facts to the unit tests and updated the beaker tests with beaker-puppet_install_helper and beaker-module_install_helper. These simplify test setup (it also happened to be the easiest way to get tests working consistently). 