### PR TITLE
Database port is expected to be an Integer with puppet 4

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,7 +27,7 @@ class puppetdb::params inherits puppetdb::globals {
 
   # The remaining database settings are not used for an embedded database
   $database_host          = 'localhost'
-  $database_port          = '5432'
+  $database_port          = 5432
   $database_name          = 'puppetdb'
   $database_username      = 'puppetdb'
   $database_password      = 'puppetdb'


### PR DESCRIPTION
The default value uses a String, which clashes with the current
puppetlabs-postgres module and Puppet 4.
The error given is:
``` shell
Error: Could not retrieve catalog from remote server: Error 500 on
SERVER: Server Error: Evaluation Error: Error while evaluating a
Resource Statement, Postgresql::Server::Grant[database:GRANT puppetdb -
all - puppetdb]: parameter 'port' expects an Integer value, got String
at
/etc/puppetlabs/code/environments/production/modules/postgresql/manifests/server/database_grant.pp:10
on node node.domain
```