### PR TITLE
README: Fixes for postgres default version and header rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,7 +677,7 @@ Defaults to `undef`, using the PuppetDB built-in default.
 
 #### `disable_update_checking`
 
-Setting this to true disables checking for updated versions of PuppetDB and sending basic analytics data to Puppet. 
+Setting this to true disables checking for updated versions of PuppetDB and sending basic analytics data to Puppet.
 Defaults to `undef`, using the PuppetDB built-in default.
 
 #### `certificate_whitelist_file`
@@ -868,7 +868,7 @@ be installed from the regular repository. Defaults to `true`.
 #### `postgres_version`
 
 If the postgresql.org repo is installed, you can install several versions of
-postgres. Defaults to `9.4`, the latest stable version.
+postgres. Defaults to `9.6` in module version 6.0+ and `9.4` in older versions.
 
 Implementation
 ---------------

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 puppetdb
 =========
 
-####Table of Contents
+#### Table of Contents
 
 1. [Overview - What is the PuppetDB module?](#overview)
 2. [Module Description - What does the module do?](#module-description)
@@ -298,7 +298,7 @@ You must declare the class to use it:
 
 **Parameters within `puppetdb::globals`:**
 
-####`version`
+#### `version`
 
 The version of the `puppetdb` package that should be installed. You may specify
 an explicit version number, 'present', or 'latest' (defaults to 'present').
@@ -319,57 +319,57 @@ You must declare the class to use it:
 
 **Parameters within `puppetdb`:**
 
-####`listen_address`
+#### `listen_address`
 
 The address that the web server should bind to for HTTP requests. Defaults to
 `localhost`. Set to `0.0.0.0` to listen on all addresses.
 
-####`listen_port`
+#### `listen_port`
 
 The port on which the puppetdb web server should accept HTTP requests. Defaults
 to `8080`.
 
-####`disable_cleartext`
+#### `disable_cleartext`
 
 If true, the puppetdb web server will only serve HTTPS and not HTTP requests (defaults to false).
 
-####`open_listen_port`
+#### `open_listen_port`
 
 If `true`, open the `http_listen_port` on the firewall. Defaults to `false`.
 
-####`ssl_listen_address`
+#### `ssl_listen_address`
 
 The address that the web server should bind to for HTTPS requests. Defaults to
 `0.0.0.0` to listen on all addresses.
 
-####`ssl_listen_port`
+#### `ssl_listen_port`
 
 The port on which the puppetdb web server should accept HTTPS requests. Defaults
 to `8081`.
 
-####`disable_ssl`
+#### `disable_ssl`
 
 If `true`, the puppetdb web server will only serve HTTP and not HTTPS requests.
 Defaults to `false`.
 
-####`open_ssl_listen_port`
+#### `open_ssl_listen_port`
 
 If true, open the `ssl_listen_port` on the firewall. Defaults to `undef`.
 
-####`ssl_protocols`
+#### `ssl_protocols`
 
 Specify the supported SSL protocols for PuppetDB (e.g. TLSv1, TLSv1.1, TLSv1.2.)
 
-####`cipher_suites`
+#### `cipher_suites`
 
 Configure jetty's supported `cipher-suites` (e.g. `SSL_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384`).
 Defaults to `undef`.
 
-###`manage_dbserver`
+### `manage_dbserver`
 
 If true, the PostgreSQL server will be managed by this module. Defaults to `true`.
 
-####`database`
+#### `database`
 
 Which database backend to use; legal values are `postgres` (default)
 or `embedded`. The `embedded` option is not supported on PuppetDB
@@ -378,33 +378,33 @@ for testing, but is not recommended for use in production
 environments. For more info, see the [puppetdb
 docs](http://docs.puppetlabs.com/puppetdb/).
 
-####`database_host`
+#### `database_host`
 
 Hostname to use for the database connection. For single case installations this
 should be left as the default. Defaults to `localhost`, ignored for `embedded`
 database.
 
-####`database_port`
+#### `database_port`
 
 The port that the database server listens on. Defaults to `5432`, ignored for
 `embedded` database.
 
-####`database_username`
+#### `database_username`
 
 The name of the database user to connect as. Defaults to `puppetdb`, ignored for
 `embedded` database.
 
-####`database_password`
+#### `database_password`
 
 The password for the database user. Defaults to `puppetdb`, ignored for
 `embedded` database.
 
-####`database_name`
+#### `database_name`
 
 The name of the database instance to connect to. Defaults to `puppetdb`, ignored
 for `embedded` database.
 
-####`database_ssl` (DEPRECATED)
+#### `database_ssl` (DEPRECATED)
 
 If true, PuppetDB will use SSL to connect to the postgres database. Defaults to
 `false`, ignored for `embedded` database. Setting up proper trust- and keystores has to
@@ -413,7 +413,7 @@ be managed outside of the PuppetDB module.
 This parameter is deprecated and will be retired in a future release. Please use
 the `jdbc_ssl_properties` parameter with the value `?ssl=true`.
 
-####`jdbc_ssl_properties`
+#### `jdbc_ssl_properties`
 
 The text to append to the JDBC connection URI. This should begin with a '?'
 character. For example, to use SSL for the PostgreSQL connection, set this
@@ -422,42 +422,42 @@ parameter's value to `?ssl=true`.
 This setting is only available when using PostgreSQL; when using HyperSQL (the
 `embedded` database), it does nothing.
 
-####`database_validate`
+#### `database_validate`
 
 If true, the module will attempt to connect to the database using the specified
 settings and fail if it is not able to do so. Defaults to `true`.
 
-####`database_embedded_path`
+#### `database_embedded_path`
 
 *Embedded Database Only* Changes the path location for the HSQLDB database. Does
  not provide migration for old data, so if you change this value and you have an
  existing database you will need to manually move the content also. (defaults to
  package default for 2.x release).
 
-####`node_ttl`
+#### `node_ttl`
 
 The length of time a node can go without receiving any new data before it's
 automatically deactivated. (defaults to '0', which disables auto-deactivation).
 This option is supported in PuppetDB >= 1.1.0.
 
-####`node_purge_ttl`
+#### `node_purge_ttl`
 
 The length of time a node can be deactivated before it's deleted from the
 database. (defaults to '0', which disables purging). This option is supported in
 PuppetDB >= 1.2.0.
 
-####`report_ttl`
+#### `report_ttl`
 
 The length of time reports should be stored before being deleted. (defaults to
 `7d`, which is a 7-day period). This option is supported in PuppetDB >= 1.1.0.
 
-####`gc_interval`
+#### `gc_interval`
 
 This controls how often (in minutes) to compact the database. The compaction
 process reclaims space and deletes unnecessary rows. If not supplied, the
 default is every 60 minutes. This option is supported in PuppetDB >= 0.9.
 
-####`log_slow_statements`
+#### `log_slow_statements`
 
 This sets the number of seconds before an SQL query is considered "slow." Slow
 SQL queries are logged as warnings, to assist in debugging and tuning. Note
@@ -467,14 +467,14 @@ complete.
 The default value is `10` seconds. A value of 0 will disable logging of slow
 queries. This option is supported in PuppetDB >= 1.1.
 
-####`conn_max_age`
+#### `conn_max_age`
 
 The maximum time (in minutes) for a pooled connection to remain unused before
 it is closed off.
 
 If not supplied, we default to `60` minutes. This option is supported in PuppetDB >= 1.1.
 
-####`conn_keep_alive`
+#### `conn_keep_alive`
 
 This sets the time (in minutes) for a connection to remain idle before sending
 a test query to the DB. This is useful to prevent a DB from timing out
@@ -482,7 +482,7 @@ connections on its end.
 
 If not supplied, we default to 45 minutes. This option is supported in PuppetDB >= 1.1.
 
-####`conn_lifetime`
+#### `conn_lifetime`
 
 The maximum time (in minutes) a pooled connection should remain open. Any
 connections older than this setting will be closed off. Connections currently in
@@ -491,29 +491,29 @@ use will not be affected until they are returned to the pool.
 If not supplied, we won't terminate connections based on their age alone. This
 option is supported in PuppetDB >= 1.4.
 
-####`puppetdb_package`
+#### `puppetdb_package`
 
 The PuppetDB package name in the package manager. Defaults to `present`.
 
-####`puppetdb_service`
+#### `puppetdb_service`
 
 The name of the PuppetDB service. Defaults to `puppetdb`.
 
-####`puppetdb_service_status`
+#### `puppetdb_service_status`
 
 Sets whether the service should be `running ` or `stopped`. When set to `stopped` the
 service doesn't start on boot either. Valid values are `true`, `running`,
 `false`, and `stopped`.
 
-####`confdir`
+#### `confdir`
 
 The PuppetDB configuration directory. Defaults to `/etc/puppetdb/conf.d`.
 
-####`vardir`
+#### `vardir`
 
 The parent directory for the MQ's data directory.
 
-####`java_args`
+#### `java_args`
 
 Java VM options used for overriding default Java VM options specified in
 PuppetDB package. Defaults to `{}`. See
@@ -527,57 +527,57 @@ For example, to set `-Xmx512m -Xms256m` options use:
         '-Xms' => '256m',
     }
 
-####`merge_default_java_args`
+#### `merge_default_java_args`
 
 Sets whether the provided java args should be merged with the defaults, or
 should override the defaults. This setting is necessary if any of the defaults
 are to be removed. Defaults to true. If `false`, the `java_args` in the PuppetDB
 init config file will reflect only what is passed via the `java_args` param.
 
-####`max_threads`
+#### `max_threads`
 
 Jetty option to explicitly set `max-threads`. Defaults to `undef`, so the
 PuppetDB-Jetty default is used.
 
-####`read_database`
+#### `read_database`
 
 Which database backend to use for the read database. Only supports
 `postgres` (default). This option is supported in PuppetDB >= 1.6.
 
-####`read_database_host`
+#### `read_database_host`
 *This parameter must be set to enable the PuppetDB read-database.*
 
 The hostname or IP address of the read database server. Defaults to `undef`.
 The default is to use the regular database for reads and writes. This option is
 supported in PuppetDB >= 1.6.
 
-####`read_database_port`
+#### `read_database_port`
 
 The port that the read database server listens on. Defaults to `5432`. This
 option is supported in PuppetDB >= 1.6.
 
-####`read_database_username`
+#### `read_database_username`
 
 The name of the read database user to connect as. Defaults to `puppetdb`. This
 option is supported in PuppetDB >= 1.6.
 
-####`read_database_password`
+#### `read_database_password`
 
 The password for the read database user. Defaults to `puppetdb`. This option is
 supported in PuppetDB >= 1.6.
 
-####`read_database_name`
+#### `read_database_name`
 
 The name of the read database instance to connect to. Defaults to `puppetdb`.
 This option is supported in PuppetDB >= 1.6.
 
-####`read_database_ssl`
+#### `read_database_ssl`
 
 If true, PuppetDB will use SSL to connect to the postgres read database
 (defaults to false). Setting up proper trust- and keystores has to be managed
 outside of the PuppetDB module. This option is supported in PuppetDB >= 1.6.
 
-####`read_log_slow_statements`
+#### `read_log_slow_statements`
 
 This sets the number of seconds before an SQL query to the read database is
 considered "slow." Slow SQL queries are logged as warnings, to assist in
@@ -587,14 +587,14 @@ reports them after they complete.
 The default value is 10 seconds. A value of 0 will disable logging of slow
 queries. This option is supported in PuppetDB >= 1.6.
 
-####`read_conn_max_age`
+#### `read_conn_max_age`
 
 The maximum time (in minutes) for a pooled read database connection to remain
 unused before it is closed off.
 
 If not supplied, we default to 60 minutes. This option is supported in PuppetDB >= 1.6.
 
-####`read_conn_keep_alive`
+#### `read_conn_keep_alive`
 
 This sets the time (in minutes) for a read database connection to remain idle
 before sending a test query to the DB. This is useful to prevent a DB from
@@ -602,7 +602,7 @@ timing out connections on its end.
 
 If not supplied, we default to 45 minutes. This option is supported in PuppetDB >= 1.6.
 
-####`read_conn_lifetime`
+#### `read_conn_lifetime`
 
 The maximum time (in minutes) a pooled read database connection should remain
 open. Any connections older than this setting will be closed off. Connections
@@ -611,80 +611,80 @@ currently in use will not be affected until they are returned to the pool.
 If not supplied, we won't terminate connections based on their age alone. This
 option is supported in PuppetDB >= 1.6.
 
-####`ssl_dir`
+#### `ssl_dir`
 
 Base directory for PuppetDB SSL configuration. Defaults to `/etc/puppetdb/ssl`
 or `/etc/puppetlabs/puppetdb/ssl` for FOSS and PE respectively.
 
-####`ssl_set_cert_paths`
+#### `ssl_set_cert_paths`
 
 A switch to enable or disable the management of SSL certificates in your
 `jetty.ini` configuration file.
 
-####`ssl_cert_path`
+#### `ssl_cert_path`
 
 Path to your SSL certificate for populating `jetty.ini`.
 
-####`ssl_key_path`
+#### `ssl_key_path`
 
 Path to your SSL key for populating `jetty.ini`.
 
-####`ssl_ca_cert_path`
+#### `ssl_ca_cert_path`
 
 Path to your SSL CA for populating `jetty.ini`.
 
-####`ssl_deploy_certs`
+#### `ssl_deploy_certs`
 
 A boolean switch to enable or disable the management of SSL keys in your
 `ssl_dir`. Default is `false`.
 
-####`ssl_key`
+#### `ssl_key`
 
 Contents of your SSL key, as a string.
 
-####`ssl_cert`
+#### `ssl_cert`
 
 Contents of your SSL certificate, as a string.
 
-####`ssl_ca_cert`
+#### `ssl_ca_cert`
 
 Contents of your SSL CA certificate, as a string.
 
-####`manage_firewall`
+#### `manage_firewall`
 
 If `true`, puppet will manage your iptables rules for PuppetDB via the
 [puppetlabs-firewall](https://forge.puppetlabs.com/puppetlabs/firewall) class.
 
-####`command_threads`
+#### `command_threads`
 
 The number of command processing threads to use. Defaults to `undef`, using the
 PuppetDB built-in default.
 
-####`concurrent_writes`
+#### `concurrent_writes`
 
 The number of threads allowed to write to disk at any one time. Defaults to
 `undef`, which uses the PuppetDB built-in default.
 
-####`store_usage`
+#### `store_usage`
 
 The amount of disk space (in MB) to allow for persistent message storage.
 Defaults to `undef`, using the PuppetDB built-in default.
 
-####`temp_usage`
+#### `temp_usage`
 
 The amount of disk space (in MB) to allow for temporary message storage.
 Defaults to `undef`, using the PuppetDB built-in default.
 
-####`disable_update_checking`
+#### `disable_update_checking`
 
 Setting this to true disables checking for updated versions of PuppetDB and sending basic analytics data to Puppet. 
 Defaults to `undef`, using the PuppetDB built-in default.
 
-####`certificate_whitelist_file`
+#### `certificate_whitelist_file`
 
 The name of the certificate whitelist file to set up and configure in PuppetDB. Defaults to `/etc/puppetdb/certificate-whitelist` or `/etc/puppetlabs/puppetdb/certificate-whitelist` for FOSS and PE respectively.
 
-####`certificate_whitelist`
+#### `certificate_whitelist`
 
 Array of the X.509 certificate Common Names of clients allowed to connect to PuppetDB. Defaults to empty. Be aware that this permits full access to all Puppet clients to download anything contained in PuppetDB, including the full catalogs of all nodes, which possibly contain sensitive information. Set to `[ $::servername ]` to allow access only from your (single) Puppet master, which is enough for normal operation. Set to a list of Puppet masters if you have multiple.
 
@@ -721,49 +721,49 @@ from managing that file, and you’ll need to manage it yourself.
 
 **Parameters within `puppetdb::master::config`:**
 
-####`puppetdb_server`
+#### `puppetdb_server`
 
 The dns name or ip of the PuppetDB server. Defaults to the hostname of the
 current node, i.e. `$::fqdn`.
 
-####`puppetdb_port`
+#### `puppetdb_port`
 
 The port that the PuppetDB server is running on. Defaults to `8081`.
 
-####`puppetdb_disable_ssl`
+#### `puppetdb_disable_ssl`
 
 If true, use plain HTTP to talk to PuppetDB. Defaults to the value of
 `disable_ssl` if PuppetDB is on the same server as the Puppet Master, or else
 false. If you set this, you probably need to set `puppetdb_port` to match the HTTP
 port of the PuppetDB.
 
-####`puppetdb_soft_write_failure`
+#### `puppetdb_soft_write_failure`
 
 Boolean to fail in a soft manner if PuppetDB is not accessible for command
 submission Defaults to `false`.
 
-####`manage_routes`
+#### `manage_routes`
 
 If `true`, the module will overwrite the Puppet master's routes file to
 configure it to use PuppetDB. Defaults to `true`.
 
-####`manage_storeconfigs`
+#### `manage_storeconfigs`
 
 If `true`, the module will manage the Puppet master's storeconfig settings.
 Defaults to `true`.
 
-####`manage_report_processor`
+#### `manage_report_processor`
 
 If `true`, the module will manage the 'reports' field in the puppet.conf file to
 enable or disable the PuppetDB report processor. Defaults to `false`.
 
-####`manage_config`
+#### `manage_config`
 
 If `true`, the module will store values from `puppetdb_server` and `puppetdb_port`
 parameters in the PuppetDB configuration file. If `false`, an existing PuppetDB
 configuration file will be used to retrieve server and port values.
 
-####`create_puppet_service_resource`
+#### `create_puppet_service_resource`
 
 If `true`, AND if `restart_puppet` is true, then the module will create a service
 resource for `puppet_service_name` if it has not been defined. Defaults to `true`.
@@ -771,49 +771,49 @@ If you are already declaring the `puppet_service_name` service resource in anoth
 part of your code, setting this to `false` will avoid creation of that service
 resource by this module, avoiding potential duplicate resource errors.
 
-####`strict_validation`
+#### `strict_validation`
 
 If `true`, the module will fail if PuppetDB is not reachable, otherwise it will
 preconfigure PuppetDB without checking.
 
-####`enable_reports`
+#### `enable_reports`
 
 Ignored unless `manage_report_processor` is `true`, in which case this setting
 will determine whether or not the PuppetDB report processor is enabled (`true`)
 or disabled (`false`) in the puppet.conf file.
 
-####`puppet_confdir`
+#### `puppet_confdir`
 
 Puppet's config directory. Defaults to `/etc/puppet`.
 
-####`puppet_conf`
+#### `puppet_conf`
 
 Puppet's config file. Defaults to `/etc/puppet/puppet.conf`.
 
-####`masterless`
+#### `masterless`
 
 A boolean switch to enable or disable the masterless setup of PuppetDB. Defaults
 to `false`.
 
-####`terminus_package`
+#### `terminus_package`
 
 Name of the package to use that represents the PuppetDB terminus code. Defaults
 to `puppetdb-termini`, when `puppetdb_version` is set to `<= 2.3.x` the default
 changes to `puppetdb-terminus`.
 
-####`puppet_service_name`
+#### `puppet_service_name`
 
 Name of the service that represents Puppet. You can change this to `apache2` or
 `httpd` depending on your operating system, if you plan on having Puppet run
 using Apache/Passenger for example.
 
-####`puppetdb_startup_timeout`
+#### `puppetdb_startup_timeout`
 
 The maximum amount of time that the module should wait for PuppetDB to start up.
 This is most important during the initial install of PuppetDB (defaults to 15
 seconds).
 
-####`restart_puppet`
+#### `restart_puppet`
 
 If `true`, the module will restart the Puppet master when PuppetDB configuration
 files are changed by the module. Defaults to `true`. If set to `false`, you
@@ -830,42 +830,42 @@ creating and managing the PuppetDB database and database user accounts.
       listen_addresses => 'my.postgres.host.name',
     }
 
-####`listen_addresses`
+#### `listen_addresses`
 
 The `listen_address` is a comma-separated list of hostnames or IP addresses on
 which the postgres server should listen for incoming connections. This defaults
 to `localhost`. This parameter maps directly to PostgreSQL's `listen_addresses`
 config option. Use a `*` to allow connections on any accessible address.
 
-####`database_name`
+#### `database_name`
 
 Sets the name of the database. Defaults to `puppetdb`.
 
-####`database_username`
+#### `database_username`
 
 Creates a user for access the database. Defaults to `puppetdb`.
 
-####`database_password`
+#### `database_password`
 
 Sets the password for the database user above. Defaults to `puppetdb`.
 
-####`manage_server`
+#### `manage_server`
 
 Conditionally manages the PostgreSQL server via `postgresql::server`. Defaults
 to `true`. If set to `false`, this class will create the database and user via
 `postgresql::server::db` but not attempt to install or manage the server itself.
 
-####`test_url`
+#### `test_url`
 
 The URL to use for testing if the PuppetDB instance is running. Defaults to
 `/pdb/meta/v1/version`.
 
-####`manage_package_repo`
+#### `manage_package_repo`
 
 If `true`, the official postgresql.org repo will be added and postgres won't
 be installed from the regular repository. Defaults to `true`.
 
-####`postgres_version`
+#### `postgres_version`
 
 If the postgresql.org repo is installed, you can install several versions of
 postgres. Defaults to `9.4`, the latest stable version.


### PR DESCRIPTION
This fixes the rendering of the headers in the README on GitHub, and also fixes the PostgreSQL version mentioned since the default is now 9.6, not 9.4.