### PR TITLE
Fixing database_port variable to be an integer

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,7 +27,7 @@ class puppetdb::params inherits puppetdb::globals {
 
   # The remaining database settings are not used for an embedded database
   $database_host          = 'localhost'
-  $database_port          = '5432'
+  $database_port          = 5432
   $database_name          = 'puppetdb'
   $database_username      = 'puppetdb'
   $database_password      = 'puppetdb'
@@ -53,7 +53,7 @@ class puppetdb::params inherits puppetdb::globals {
   # These settings are for the read database
   $read_database                     = 'postgres'
   $read_database_host                = undef
-  $read_database_port                = '5432'
+  $read_database_port                = 5432
   $read_database_name                = 'puppetdb'
   $read_database_username            = 'puppetdb'
   $read_database_password            = 'puppetdb'


### PR DESCRIPTION
This will fix the following error from puppetlabs-postgresql 5.0.0
`Error: Evaluation Error: Error while evaluating a Resource Statement, Postgresql::Server::Grant[database:GRANT puppetdb - all - puppetdb]: parameter 'port' expects an Integer value, got String`