### PR TITLE
If we aren't managing the server, don't try to create dbs.

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -27,12 +27,12 @@ class puppetdb::database::postgresql(
     postgresql::server::extension { 'pg_trgm':
       database  => $database_name,
     }
-  }
 
-  # create the puppetdb database
-  postgresql::server::db { $database_name:
-    user     => $database_username,
-    password => $database_password,
-    grant    => 'all',
+    # create the puppetdb database
+    postgresql::server::db { $database_name:
+      user     => $database_username,
+      password => $database_password,
+      grant    => 'all',
+    }
   }
 }


### PR DESCRIPTION
This simply scoots the postgresql database creation up under the block where we are managing postgresql.  In my situation, I already have a postgresql db configured on my centralized postgresql server and don't need or want puppet to try to configure it.  (I also don't think the existing code would work anyway if you have manage_server turned off)