### PR TITLE
Error adding extension to PostgresSQL database with custom port

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -25,7 +25,8 @@ class puppetdb::database::postgresql(
     # get the pg contrib to use pg_trgm extension
     class { '::postgresql::server::contrib': }
     postgresql::server::extension { 'pg_trgm':
-      database  => $database_name,
+      database         => $database_name,
+      connect_settings => { 'PGPORT' => $database_port, },
     }
   }
 


### PR DESCRIPTION
Seeing this error with custom port:

```
Error: /Stage[main]/Puppetdb::Database::Postgresql/Postgresql::Server::Extension[pg_trgm]/Postgresql_psql[Add pg_trgm extension to puppetdb]: Could not evaluate: Error evaluating 'unless' clause, returned pid 26843 exit 2: 'psql: FATAL:  database "puppetdb" does not exist
'
```

OS: CentOS 7.3.1611
Module versions:
mod 'puppetlabs/puppetdb', '6.0.1'
mod 'puppetlabs/postgresql', '5.1.0'
