### PR TITLE
add explicit dependency db -> extension.

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -26,6 +26,7 @@ class puppetdb::database::postgresql(
     class { '::postgresql::server::contrib': }
     postgresql::server::extension { 'pg_trgm':
       database  => $database_name,
+      require   => Postgresql::Server::Db[$database_name],
     }
   }
 


### PR DESCRIPTION
The dependency to the database is missing. This should be explicitly added. `postgresql::server::extension` does not add the dependency automatically, because the database is definded below, after the extension,  so the defined() check does not work. https://github.com/puppetlabs/puppetlabs-postgresql/blob/34aa0affa233e04a25c3b4d130e6db867bff08bd/manifests/server/extension.pp#L48-L50

```
    postgresql::server::extension { 'pg_trgm':
      database  => $database_name,
      require   => Postgresql::Server::Db[$database_name],
    }
```
related to #271