### PR TITLE
add additional puppet-lint checks and fix errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ group :development, :test do
   gem 'rspec-puppet', '~> 2.0'
   gem 'rspec-puppet-facts'
   gem 'puppet-lint',  '~> 2'
+  gem 'puppet-lint-absolute_classname-check'
+  gem 'puppet-lint-trailing_comma-check'
   gem 'metadata-json-lint', '0.0.11' if RUBY_VERSION < '1.9'
   gem 'metadata-json-lint'           if RUBY_VERSION >= '1.9'
   gem 'json', '~> 1.8'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -167,7 +167,7 @@ class puppetdb (
       manage_server       => $manage_dbserver,
       manage_package_repo => $manage_package_repo,
       postgres_version    => $postgres_version,
-      before              => $database_before
+      before              => $database_before,
     }
   }
 }

--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -106,7 +106,7 @@ class puppetdb::master::config (
       default => Package[$terminus_package],
     }
 
-    class { 'puppetdb::master::routes':
+    class { '::puppetdb::master::routes':
       puppet_confdir => $puppet_confdir,
       masterless     => $masterless,
       require        => $routes_require,
@@ -122,7 +122,7 @@ class puppetdb::master::config (
       default => Package[$terminus_package],
     }
 
-    class { 'puppetdb::master::storeconfigs':
+    class { '::puppetdb::master::storeconfigs':
       puppet_conf => $puppet_conf,
       masterless  => $masterless,
       require     => $storeconfigs_require,
@@ -138,7 +138,7 @@ class puppetdb::master::config (
       default => Package[$terminus_package],
     }
 
-    class { 'puppetdb::master::report_processor':
+    class { '::puppetdb::master::report_processor':
       puppet_conf => $puppet_conf,
       masterless  => $masterless,
       enable      => $enable_reports,
@@ -154,7 +154,7 @@ class puppetdb::master::config (
       default => Package[$terminus_package],
     }
 
-    class { 'puppetdb::master::puppetdb_conf':
+    class { '::puppetdb::master::puppetdb_conf':
       server             => $puppetdb_server,
       port               => $puppetdb_port,
       soft_write_failure => $puppetdb_soft_write_failure,

--- a/manifests/master/routes.pp
+++ b/manifests/master/routes.pp
@@ -8,8 +8,8 @@ class puppetdb::master::routes (
       'facts' => {
         'terminus' => 'puppetdb',
         'cache'    => 'yaml',
-      }
-    }
+      },
+    },
   }
 ) inherits puppetdb::params {
 
@@ -23,8 +23,8 @@ class puppetdb::master::routes (
         'facts'   => {
           'terminus' => 'facter',
           'cache'    => 'puppetdb_apply',
-        }
-      }
+        },
+      },
     }
   } else {
     $routes_real = $routes

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -137,7 +137,7 @@ class puppetdb::server (
   }
 
   if $manage_firewall {
-    class { 'puppetdb::server::firewall':
+    class { '::puppetdb::server::firewall':
       http_port      => $listen_port,
       open_http_port => $open_listen_port,
       ssl_port       => $ssl_listen_port,
@@ -145,7 +145,7 @@ class puppetdb::server (
     }
   }
 
-  class { 'puppetdb::server::global':
+  class { '::puppetdb::server::global':
     vardir         => $vardir,
     confdir        => $confdir,
     puppetdb_user  => $puppetdb_user,
@@ -153,7 +153,7 @@ class puppetdb::server (
     notify         => Service[$puppetdb_service],
   }
 
-  class { 'puppetdb::server::command_processing':
+  class { '::puppetdb::server::command_processing':
     command_threads   => $command_threads,
     concurrent_writes => $concurrent_writes,
     store_usage       => $store_usage,
@@ -162,7 +162,7 @@ class puppetdb::server (
     notify            => Service[$puppetdb_service],
   }
 
-  class { 'puppetdb::server::database':
+  class { '::puppetdb::server::database':
     database               => $database,
     database_host          => $database_host,
     database_port          => $database_port,
@@ -188,7 +188,7 @@ class puppetdb::server (
     notify                 => Service[$puppetdb_service],
   }
 
-  class { 'puppetdb::server::read_database':
+  class { '::puppetdb::server::read_database':
     database               => $read_database,
     database_host          => $read_database_host,
     database_port          => $read_database_port,
@@ -240,7 +240,7 @@ class puppetdb::server (
     }
   }
 
-  class { 'puppetdb::server::jetty':
+  class { '::puppetdb::server::jetty':
     listen_address     => $listen_address,
     listen_port        => $listen_port,
     disable_cleartext  => $disable_cleartext,
@@ -260,7 +260,7 @@ class puppetdb::server (
     puppetdb_group     => $puppetdb_group,
   }
 
-  class { 'puppetdb::server::puppetdb':
+  class { '::puppetdb::server::puppetdb':
     certificate_whitelist_file => $certificate_whitelist_file,
     certificate_whitelist      => $certificate_whitelist,
     disable_update_checking    => $disable_update_checking,

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -33,7 +33,7 @@ class puppetdb::server::database (
     # Because of a limitation in the postgres module this will break with
     # a duplicate declaration if read and write database host+name are the
     # same.
-    class { 'puppetdb::server::validate_db':
+    class { '::puppetdb::server::validate_db':
       database          => $database,
       database_host     => $database_host,
       database_port     => $database_port,
@@ -62,7 +62,7 @@ class puppetdb::server::database (
     path    => $database_ini,
     ensure  => present,
     section => 'database',
-    require => $ini_setting_require
+    require => $ini_setting_require,
   }
 
   if $database == 'embedded' {

--- a/manifests/server/firewall.pp
+++ b/manifests/server/firewall.pp
@@ -5,7 +5,7 @@ class puppetdb::server::firewall (
   $ssl_port       = $puppetdb::params::ssl_listen_port,
   $open_ssl_port  = $puppetdb::params::open_ssl_listen_port,
 ) inherits puppetdb::params {
-  include firewall
+  include ::firewall
 
   if ($open_http_port) {
     firewall { "${http_port} accept - puppetdb":

--- a/manifests/server/read_database.pp
+++ b/manifests/server/read_database.pp
@@ -30,7 +30,7 @@ class puppetdb::server::read_database (
       # Because of a limitation in the postgres module this will break with
       # a duplicate declaration if read and write database host+name are the
       # same.
-      class { 'puppetdb::server::validate_read_db':
+      class { '::puppetdb::server::validate_read_db':
         database          => $database,
         database_host     => $database_host,
         database_port     => $database_port,


### PR DESCRIPTION
We're using some additional puppet-lint checks (`absolute_classname` and `trailing_comma`) in our environment that were failing.  This MR adds those checks, and fixes the errors.