### PR TITLE
use of hard-coded passwords is a bad practice 

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,6 @@
+:hierarchy:
+  - common
+:backends:
+  - yaml
+:yaml:
+:datadir: 'hieradata'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,0 +1,3 @@
+---
+db_pwd: puppetdb
+read_db_pwd: puppetdb

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,7 +30,7 @@ class puppetdb::params inherits puppetdb::globals {
   $database_port          = '5432'
   $database_name          = 'puppetdb'
   $database_username      = 'puppetdb'
-  $database_password      = 'puppetdb'
+  $database_password      = hiera('db_pwd')
   $database_ssl           = undef
   $jdbc_ssl_properties    = ''
   $database_validate      = true
@@ -56,7 +56,7 @@ class puppetdb::params inherits puppetdb::globals {
   $read_database_port                = '5432'
   $read_database_name                = 'puppetdb'
   $read_database_username            = 'puppetdb'
-  $read_database_password            = 'puppetdb'
+  $read_database_password            = hiera('read_db_pwd')
   $read_database_ssl                 = undef
   $read_database_jdbc_ssl_properties = ''
   $read_database_validate            = true


### PR DESCRIPTION
> hard-coded default passwords as parameters is a bad practice

Greetings,

I am a security researcher, who is looking for security smells in Puppet scripts.
I noticed instances of hard-coded passwords, which are against the best practices
recommended by Common Weakness Enumeration (CWE) [https://cwe.mitre.org/data/definitions/259.html] and also by other security practitioners.
I suggest use of undef to mitigate this smell. Feedback is welcome.
