### PR TITLE
(PDB-4092) Use vardir prefix for DLO path

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -294,7 +294,8 @@ class puppetdb::server (
       systemd::unit_file{'puppetdb-dlo-cleanup.service':
         content => epp("${module_name}/puppetdb-DLO-cleanup.service.epp", {
           'puppetdb_user'  => $puppetdb_user,
-          'puppetdb_group' =>  $puppetdb_group,
+          'puppetdb_group' => $puppetdb_group,
+          'vardir'         => $vardir,
           'dlo_max_age'    => $dlo_max_age
         }),
       }
@@ -311,7 +312,7 @@ class puppetdb::server (
         monthday => '*',
         month    => '*',
         weekday  => '*',
-        command  => "/usr/bin/find /opt/puppetlabs/server/data/puppetdb/stockpile/discard/ -type f -mtime ${dlo_max_age} -delete",
+        command  => "/usr/bin/find ${vardir}/stockpile/discard/ -type f -mtime ${dlo_max_age} -delete",
         user     => $puppetdb_user,
       }
     }

--- a/spec/unit/classes/server_spec.rb
+++ b/spec/unit/classes/server_spec.rb
@@ -86,7 +86,7 @@ describe 'puppetdb::server', type: :class do
         end
 
         describe 'by default dlo cleanup service is enabled' do
-          it { is_expected.to contain_systemd__unit_file('puppetdb-dlo-cleanup.service') }
+          it { is_expected.to contain_systemd__unit_file('puppetdb-dlo-cleanup.service').with_content(%r{/opt/puppetlabs/server/data/puppetdb/stockpile/discard/}) }
           it { is_expected.to contain_systemd__unit_file('puppetdb-dlo-cleanup.timer').with_enable(true).with_active(true) }
 
           it { is_expected.not_to contain_cron('puppetdb-dlo-cleanup') }
@@ -103,11 +103,24 @@ describe 'puppetdb::server', type: :class do
           it { is_expected.not_to contain_systemd__unit_file('puppetdb-dlo-cleanup.timer') }
           it { is_expected.not_to contain_cron('puppetdb-dlo-cleanup') }
         end
+
+        describe 'dlo directory is customized by $vardir to $vardir/stockpile/discard' do
+          let(:params) do
+            {
+              'vardir' => '/var/custom/path',
+            }
+          end
+
+          it { is_expected.to contain_systemd__unit_file('puppetdb-dlo-cleanup.service').with_content(%r{/var/custom/path/stockpile/discard/}) }
+          it { is_expected.to contain_systemd__unit_file('puppetdb-dlo-cleanup.timer').with_enable(true).with_active(true) }
+
+          it { is_expected.not_to contain_cron('puppetdb-dlo-cleanup') }
+        end
       end
 
       context 'when systemd is not available' do
         describe 'by default dlo cleanup is set up with cron' do
-          it { is_expected.to contain_cron('puppetdb-dlo-cleanup').with_ensure('present') }
+          it { is_expected.to contain_cron('puppetdb-dlo-cleanup').with_ensure('present').with(command: %r{/opt/puppetlabs/server/data/puppetdb/stockpile/discard/}) }
 
           it { is_expected.not_to contain_systemd__unit_file('puppetdb-dlo-cleanup.service') }
           it { is_expected.not_to contain_systemd__unit_file('puppetdb-dlo-cleanup.timer') }
@@ -123,6 +136,19 @@ describe 'puppetdb::server', type: :class do
           it { is_expected.not_to contain_systemd__unit_file('puppetdb-dlo-cleanup.service') }
           it { is_expected.not_to contain_systemd__unit_file('puppetdb-dlo-cleanup.timer') }
           it { is_expected.not_to contain_cron('puppetdb-dlo-cleanup') }
+        end
+
+        describe 'dlo directory is customized by $vardir to $vardir/stockpile/discard' do
+          let(:params) do
+            {
+              'vardir' => '/var/custom/path',
+            }
+          end
+
+          it { is_expected.to contain_cron('puppetdb-dlo-cleanup').with_ensure('present').with(command: %r{/var/custom/path/stockpile/discard/}) }
+
+          it { is_expected.not_to contain_systemd__unit_file('puppetdb-dlo-cleanup.service') }
+          it { is_expected.not_to contain_systemd__unit_file('puppetdb-dlo-cleanup.timer') }
         end
       end
     end

--- a/templates/puppetdb-DLO-cleanup.service.epp
+++ b/templates/puppetdb-DLO-cleanup.service.epp
@@ -1,5 +1,6 @@
 <%- | String[1] $puppetdb_user,
       String[1] $puppetdb_group,
+      String[1] $vardir,
       Integer[1] $dlo_max_age
 | -%>
 [Unit]
@@ -9,4 +10,4 @@ Description=Cleanup old discarded puppetdb reports
 Type=oneshot
 User=<%= $puppetdb_user %>
 Group=<%= $puppetdb_group %>
-ExecStart=/usr/bin/find /opt/puppetlabs/server/data/puppetdb/stockpile/discard/ -type f -mtime +<%= $dlo_max_age %> -delete
+ExecStart=/usr/bin/find <%= $vardir %>/stockpile/discard/ -type f -mtime +<%= $dlo_max_age %> -delete


### PR DESCRIPTION
Previously, the DLO path was hardcoded in with its default value. This
means that when attempting to clean a DLO store on a system using a
non-default location for vardir, the puppetdb module would attempt to
remove a directory that was not actually the DLO store (if it existed at
all).

Now, in accordance with how puppetdb selects the DLO store location, the
puppetdb module will use `<vardir>/stockpile/discard/` as the DLO
location.