### PR TITLE
Create enable_storeconfigs option for puppet::master::config

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,6 +793,12 @@ Ignored unless `manage_report_processor` is `true`, in which case this setting
 will determine whether or not the PuppetDB report processor is enabled (`true`)
 or disabled (`false`) in the puppet.conf file.
 
+#### `enable_storeconfigs`
+
+Ignored unless `manage_storeconfigs` is `true`, in which case this setting
+will determine whether or not client configuration storage is enabled (`true`)
+or disabled (`false`) in the puppet.conf file.
+
 #### `puppet_confdir`
 
 Puppet's config directory. Defaults to `/etc/puppet`.

--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -16,6 +16,7 @@ class puppetdb::master::config (
   $puppetdb_soft_write_failure = false,
   $manage_routes               = true,
   $manage_storeconfigs         = true,
+  $enable_storeconfigs         = true,
   $manage_report_processor     = false,
   $manage_config               = true,
   $create_puppet_service_resource = true,
@@ -125,6 +126,7 @@ class puppetdb::master::config (
     class { 'puppetdb::master::storeconfigs':
       puppet_conf => $puppet_conf,
       masterless  => $masterless,
+      enable      => $enable_storeconfigs,
       require     => $storeconfigs_require,
     }
   }

--- a/manifests/master/storeconfigs.pp
+++ b/manifests/master/storeconfigs.pp
@@ -3,7 +3,7 @@
 class puppetdb::master::storeconfigs (
   $puppet_conf = $puppetdb::params::puppet_conf,
   $masterless  = $puppetdb::params::masterless,
-  $enable      = false,
+  $enable      = true,
 ) inherits puppetdb::params {
 
   if $masterless {

--- a/manifests/master/storeconfigs.pp
+++ b/manifests/master/storeconfigs.pp
@@ -3,6 +3,7 @@
 class puppetdb::master::storeconfigs (
   $puppet_conf = $puppetdb::params::puppet_conf,
   $masterless  = $puppetdb::params::masterless,
+  $enable      = false,
 ) inherits puppetdb::params {
 
   if $masterless {
@@ -11,10 +12,15 @@ class puppetdb::master::storeconfigs (
     $puppet_conf_section = 'master'
   }
 
+  $storeconfigs_ensure = $enable ? {
+    true    => present,
+    default => absent,
+  }
+
   Ini_setting {
     section => $puppet_conf_section,
     path    => $puppet_conf,
-    ensure  => present,
+    ensure  => $storeconfigs_ensure,
   }
 
   ini_setting { "puppet.conf/${puppet_conf_section}/storeconfigs":


### PR DESCRIPTION
(MODULES-9905) Create enable_storeconfigs option for puppet::master::config

This creates a flag to allow the removal of 'storeconfigs' and 'storeconfigs_backend' directives from puppet.conf when those directives are managed by the module.

No tests are included here because there was no unit test to begin with(?!).