### PR TITLE
(PDB-4945) Default to json fact cache

### DIFF
--- a/manifests/master/routes.pp
+++ b/manifests/master/routes.pp
@@ -3,14 +3,7 @@
 class puppetdb::master::routes (
   $puppet_confdir = $puppetdb::params::puppet_confdir,
   $masterless     = $puppetdb::params::masterless,
-  $routes         = {
-    'master' => {
-      'facts' => {
-        'terminus' => 'puppetdb',
-        'cache'    => 'yaml',
-      }
-    }
-  }
+  $routes         = undef,
 ) inherits puppetdb::params {
 
   if $masterless {
@@ -26,8 +19,22 @@ class puppetdb::master::routes (
         }
       }
     }
-  } else {
+  } elsif $routes {
     $routes_real = $routes
+  } else {
+    if versioncmp($serverversion, '7.0') == -1 {
+      $default_fact_cache = 'yaml'
+    } else {
+      $default_fact_cache = 'json'
+    }
+    $routes_real = {
+      'master' => {
+        'facts' => {
+          'terminus' => 'puppetdb',
+          'cache'    => $default_fact_cache,
+        }
+      }
+    }
   }
 
   # TODO: this will overwrite any existing routes.yaml;

--- a/manifests/master/routes.pp
+++ b/manifests/master/routes.pp
@@ -22,10 +22,10 @@ class puppetdb::master::routes (
   } elsif $routes {
     $routes_real = $routes
   } else {
-    if versioncmp($serverversion, '7.0') == -1 {
-      $default_fact_cache = 'yaml'
-    } else {
+    if (defined('$serverversion')) and (versioncmp($serverversion, '7.0') >= 0) {
       $default_fact_cache = 'json'
+    } else {
+      $default_fact_cache = 'yaml'
     }
     $routes_real = {
       'master' => {

--- a/spec/unit/classes/master/config_spec.rb
+++ b/spec/unit/classes/master/config_spec.rb
@@ -86,6 +86,12 @@ describe 'puppetdb::master::config', type: :class do
         operatingsystemrelease: '7.0',
         kernel: 'Linux',
         selinux: true,
+        os: {
+          family: 'RedHat',
+          name: 'RedHat',
+          release: { 'full' => '7.0' },
+          selinux: { 'enabled' => true },
+        },
       }
     end
     let(:pre_condition) { 'class { "puppetdb::globals": version => "3.1.1-1.el7", }' }
@@ -102,6 +108,12 @@ describe 'puppetdb::master::config', type: :class do
         operatingsystemrelease: '7.0',
         kernel: 'Linux',
         selinux: true,
+        os: {
+          family: 'RedHat',
+          name: 'RedHat',
+          release: { 'full' => '7.0' },
+          selinux: { 'enabled' => true },
+        },
       }
     end
 


### PR DESCRIPTION
Puppetserver 7 now defaults the fact cache to json[1]. When running in
agent-server mode, configure routes.yaml the same way. There is no change in
behavior when running with puppetserver < 7 or `puppet apply`.

As a result of this change, when the puppetdb module is used to install the
puppetdb terminus and routes.yaml, facts will now be cached as non-pretty json
in:

     /opt/puppetlabs/server/data/puppetserver/server_data/facts/<node>.json

Instead of pretty yaml in:

     /opt/puppetlabs/server/data/puppetserver/yaml/<node>.yaml

The difference in pathing is due to the abstract yaml and json termini using
different base directories in which to store data: `Puppet[:yamldir]` vs
`Puppet[:server_data]`.

[1] https://github.com/puppetlabs/puppetserver/blob/794e725628545aa075e3f8b5fa91f21628373594/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb#L56