### PR TITLE
(maint) Update to structured facts

### DIFF
--- a/spec/unit/classes/master/config_spec.rb
+++ b/spec/unit/classes/master/config_spec.rb
@@ -86,6 +86,12 @@ describe 'puppetdb::master::config', type: :class do
         operatingsystemrelease: '7.0',
         kernel: 'Linux',
         selinux: true,
+        os: {
+          family: 'RedHat',
+          name: 'RedHat',
+          release: { 'full' => '7.0' },
+          selinux: { 'enabled' => true },
+        },
       }
     end
     let(:pre_condition) { 'class { "puppetdb::globals": version => "3.1.1-1.el7", }' }
@@ -102,6 +108,12 @@ describe 'puppetdb::master::config', type: :class do
         operatingsystemrelease: '7.0',
         kernel: 'Linux',
         selinux: true,
+        os: {
+          family: 'RedHat',
+          name: 'RedHat',
+          release: { 'full' => '7.0' },
+          selinux: { 'enabled' => true },
+        },
       }
     end
 


### PR DESCRIPTION
The current specs are failing due to the move of the postgress module to structured facts: https://github.com/puppetlabs/puppetlabs-postgresql/pull/1191

There was an attempt to move this module to structured facts here: https://github.com/mihaibuzgau/puppetlabs-puppetdb/commit/314e045b4756c69366998f8a634d5cc873de9df2, however, this work cannot be fully implemented because puppetlabs-firewall was not yet updated.

This PR updates the facter stubs to also set structured facts. 