### PR TITLE
Fix reference to PuppetDB documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ The parent directory for the MQ's data directory.
 
 Java VM options used for overriding default Java VM options specified in
 PuppetDB package. Defaults to `{}`. See
-[PuppetDB Configuration](http://docs.puppetlabs.com/puppetdb/1.1/configure.html)
+[PuppetDB Configuration](http://docs.puppetlabs.com/puppetdb/latest/configure.html)
 to get more details about the current defaults.
 
 For example, to set `-Xmx512m -Xms256m` options use:


### PR DESCRIPTION
Version 1.1 has been archived, suggest linking to latest instead to be safe.