### PR TITLE
cron puppetdb-dlo-cleanup requires package

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -664,6 +664,7 @@ class puppetdb::server (
         weekday  => '*',
         command  => "/usr/bin/find ${vardir}/stockpile/discard/ -type f -mtime ${dlo_max_age} -delete",
         user     => $puppetdb_user,
+        require  => Package[$puppetdb_package],
       }
     }
   }


### PR DESCRIPTION
Fixes the following error

Error: /Stage[main]/Puppetdb::Server/Cron[puppetdb-dlo-cleanup]: Could not evaluate: Cannot write the puppetdb user's crontab: The user does not exist