### PR TITLE
(SERVER-2500) Allow puppetlabs-postgresql 7.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/postgresql",
-      "version_requirement": ">= 4.0.0 < 7.0.0"
+      "version_requirement": ">= 4.0.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/firewall",


### PR DESCRIPTION
This allows us to pick up the dnf changes added in [puppetlabs-postgres/pr/1239](https://github.com/puppetlabs/puppetlabs-postgresql/pull/1239) which addresses issues installing postgres on el8. 