### PR TITLE
Sync TTL default values in the README with actual defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,19 +497,20 @@ settings and fail if it is not able to do so. Defaults to `true`.
 #### `node_ttl`
 
 The length of time a node can go without receiving any new data before it's
-automatically deactivated. (defaults to '0', which disables auto-deactivation).
-This option is supported in PuppetDB >= 1.1.0.
+automatically deactivated. (defaults to '7d', which is a 7-day period. Set to
+'0' to disable auto-deactivation).  This option is supported in PuppetDB >=
+1.1.0.
 
 #### `node_purge_ttl`
 
 The length of time a node can be deactivated before it's deleted from the
-database. (defaults to '0', which disables purging). This option is supported in
-PuppetDB >= 1.2.0.
+database. (defaults to '14d', which is a 14-day period. Set to '0' to disable
+purging). This option is supported in PuppetDB >= 1.2.0.
 
 #### `report_ttl`
 
 The length of time reports should be stored before being deleted. (defaults to
-`7d`, which is a 7-day period). This option is supported in PuppetDB >= 1.1.0.
+`14d`, which is a 14-day period). This option is supported in PuppetDB >= 1.1.0.
 
 #### `gc_interval`
 

--- a/README.md
+++ b/README.md
@@ -498,13 +498,13 @@ settings and fail if it is not able to do so. Defaults to `true`.
 
 The length of time a node can go without receiving any new data before it's
 automatically deactivated. (defaults to '7d', which is a 7-day period. Set to
-'0' to disable auto-deactivation).  This option is supported in PuppetDB >=
+'0d' to disable auto-deactivation).  This option is supported in PuppetDB >=
 1.1.0.
 
 #### `node_purge_ttl`
 
 The length of time a node can be deactivated before it's deleted from the
-database. (defaults to '14d', which is a 14-day period. Set to '0' to disable
+database. (defaults to '14d', which is a 14-day period. Set to '0d' to disable
 purging). This option is supported in PuppetDB >= 1.2.0.
 
 #### `report_ttl`


### PR DESCRIPTION
The TTL values from the readme do not correspond to those [configured by the module](MOD) and are the [default values from PuppetDB](PDB).

Adjust the README so that it describes the actual configuration.

[MOD]: https://github.com/puppetlabs/puppetlabs-puppetdb/blob/11dc0dfd91b26e9babc31b0221cd2442ae1b46a9/manifests/params.pp#L40-L43
[PDB]: https://puppet.com/docs/puppetdb/latest/configure.html#node-ttl