### PR TITLE
(PDB-5085) - add puppet port(8140) to firewall rules

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -218,4 +218,7 @@ class puppetdb::params inherits puppetdb::globals {
 
   # java binary path for PuppetDB. If undef, default will be used.
   $java_bin = undef
+
+  # puppetserver default port
+  $puppetserver_default_port = '8140'
 }

--- a/manifests/server/firewall.pp
+++ b/manifests/server/firewall.pp
@@ -1,11 +1,18 @@
 # PRIVATE CLASS - do not use directly
 class puppetdb::server::firewall (
-  $http_port      = $puppetdb::params::listen_port,
-  $open_http_port = $puppetdb::params::open_listen_port,
-  $ssl_port       = $puppetdb::params::ssl_listen_port,
-  $open_ssl_port  = $puppetdb::params::open_ssl_listen_port,
+  $http_port         = $puppetdb::params::listen_port,
+  $open_http_port    = $puppetdb::params::open_listen_port,
+  $ssl_port          = $puppetdb::params::ssl_listen_port,
+  $open_ssl_port     = $puppetdb::params::open_ssl_listen_port,
+  $puppetserver_port = $puppetdb::params::puppetserver_default_port,
 ) inherits puppetdb::params {
   include firewall
+
+  firewall { "${puppetserver_port} accept - puppetserver":
+    dport  => $puppetserver_port,
+    proto  => 'tcp',
+    action => 'accept',
+  }
 
   if ($open_http_port) {
     firewall { "${http_port} accept - puppetdb":


### PR DESCRIPTION
When puppetdb is installed on same machine as puppetserver using puppetdb module puppetserver can't communicate with his agents anymore. After I flush all rules from iptables and restart puppetserver all works good.

**Steps to reproduce**
1. setup puppet server with one agent
2. use this site.pp
```puppet
node default {}

node 'agent_hostname' {
  notify { 'Hello':
    message => 'Hello from server',
  }
}

node 'puppetserver_hostname' {
  class { 'puppetdb': }
  class { 'puppetdb::master::config': }
}
```
3. run `puppet agent -t` on the `puppetserver` machine to install `puppetdb`
4. run `puppet agent -t` on the agent machine

**Desired behavior**
The puppetdb and puppetserver should work properly and be both must be able to communicate with agents

**Actual behavior**
```shell
Error: Connection to https://smaller-mandrel.delivery.puppetlabs.net:8140/puppet/v3 failed, trying next route: Request to https://smaller-mandrel.delivery.puppetlabs.net:8140/puppet/v3 failed after 0.002 seconds: Failed to open TCP connection to smaller-mandrel.delivery.puppetlabs.net:8140 (No route to host - connect(2) for "smaller-mandrel.delivery.puppetlabs.net" port 8140)
--
Wrapped exception:
Failed to open TCP connection to smaller-mandrel.delivery.puppetlabs.net:8140 (No route to host - connect(2) for "smaller-mandrel.delivery.puppetlabs.net" port 8140)
Warning: Unable to fetch my node definition, but the agent run will continue:
Warning: No more routes to puppet
Info: Retrieving pluginfacts
Error: Connection to https://smaller-mandrel.delivery.puppetlabs.net:8140/puppet/v3 failed, trying next route: Request to https://smaller-mandrel.delivery.puppetlabs.net:8140/puppet/v3 failed after 0.001 seconds: Failed to open TCP connection to smaller-mandrel.delivery.puppetlabs.net:8140 (No route to host - connect(2) for "smaller-mandrel.delivery.puppetlabs.net" port 8140)
Wrapped exception:
Failed to open TCP connection to smaller-mandrel.delivery.puppetlabs.net:8140 (No route to host - connect(2) for "smaller-mandrel.delivery.puppetlabs.net" port 8140)
Error: /File[/opt/puppetlabs/puppet/cache/facts.d]: Failed to generate additional resources using 'eval_generate': No more routes to fileserver
Error: Connection to https://smaller-mandrel.delivery.puppetlabs.net:8140/puppet/v3 failed, trying next route: Request to https://smaller-mandrel.delivery.puppetlabs.net:8140/puppet/v3 failed after 0.001 seconds: Failed to open TCP connection to smaller-mandrel.delivery.puppetlabs.net:8140 (No route to host - connect(2) for "smaller-mandrel.delivery.puppetlabs.net" port 8140)
Wrapped exception:
Failed to open TCP connection to smaller-mandrel.delivery.puppetlabs.net:8140 (No route to host - connect(2) for "smaller-mandrel.delivery.puppetlabs.net" port 8140)
Error: /File[/opt/puppetlabs/puppet/cache/facts.d]: Could not evaluate: Could not retrieve file metadata for puppet:///pluginfacts: No more routes to fileserver
Info: Retrieving plugin
Error: Connection to https://smaller-mandrel.delivery.puppetlabs.net:8140/puppet/v3 failed, trying next route: Request to https://smaller-mandrel.delivery.puppetlabs.net:8140/puppet/v3 failed after 0.001 seconds: Failed to open TCP connection to smaller-mandrel.delivery.puppetlabs.net:8140 (No route to host - connect(2) for "smaller-mandrel.delivery.puppetlabs.net" port 8140)
Wrapped exception:
Failed to open TCP connection to smaller-mandrel.delivery.puppetlabs.net:8140 (No route to host - connect(2) for "smaller-mandrel.delivery.puppetlabs.net" port 8140)
Error: /File[/opt/puppetlabs/puppet/cache/lib]: Failed to generate additional resources using 'eval_generate': No more routes to fileserver
Error: Connection to https://smaller-mandrel.delivery.puppetlabs.net:8140/puppet/v3 failed, trying next route: Request to https://smaller-mandrel.delivery.puppetlabs.net:8140/puppet/v3 failed after 0.001 seconds: Failed to open TCP connection to smaller-mandrel.delivery.puppetlabs.net:8140 (No route to host - connect(2) for "smaller-mandrel.delivery.puppetlabs.net" port 8140)
Wrapped exception:
Failed to open TCP connection to smaller-mandrel.delivery.puppetlabs.net:8140 (No route to host - connect(2) for "smaller-mandrel.delivery.puppetlabs.net" port 8140)
Error: /File[/opt/puppetlabs/puppet/cache/lib]: Could not evaluate: Could not retrieve file metadata for puppet:///plugins: No more routes to fileserver
Error: Connection to https://smaller-mandrel.delivery.puppetlabs.net:8140/puppet/v3 failed, trying next route: Request to https://smaller-mandrel.delivery.puppetlabs.net:8140/puppet/v3 failed after 0.001 seconds: Failed to open TCP connection to smaller-mandrel.delivery.puppetlabs.net:8140 (No route to host - connect(2) for "smaller-mandrel.delivery.puppetlabs.net" port 8140)
Wrapped exception:
Failed to open TCP connection to smaller-mandrel.delivery.puppetlabs.net:8140 (No route to host - connect(2) for "smaller-mandrel.delivery.puppetlabs.net" port 8140)
Error: Could not retrieve catalog from remote server: No more routes to puppet
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
Error: Connection to https://smaller-mandrel.delivery.puppetlabs.net:8140/puppet/v3 failed, trying next route: Request to https://smaller-mandrel.delivery.puppetlabs.net:8140/puppet/v3 failed after 1.002 seconds: Failed to open TCP connection to smaller-mandrel.delivery.puppetlabs.net:8140 (No route to host - connect(2) for "smaller-mandrel.delivery.puppetlabs.net" port 8140)
Wrapped exception:
Failed to open TCP connection to smaller-mandrel.delivery.puppetlabs.net:8140 (No route to host - connect(2) for "smaller-mandrel.delivery.puppetlabs.net" port 8140)
Error: Could not send report: No more routes to report
```