### PR TITLE
allow current versions of inifile, firewall, stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 1.1.3 < 5.0.0"
+      "version_requirement": ">= 1.1.3 < 6.0.0"
     },
     {
       "name": "puppetlabs/postgresql",
@@ -18,11 +18,11 @@
     },
     {
       "name": "puppetlabs/firewall",
-      "version_requirement": ">= 1.1.3 < 3.0.0"
+      "version_requirement": ">= 1.1.3 < 4.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 7.0.0"
+      "version_requirement": ">= 4.13.1 < 8.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
`metadata.json` update to allow the current versions of the inifile, firewall, and stdlib modules.