### PR TITLE
Switch cache type on client version

### DIFF
--- a/manifests/master/routes.pp
+++ b/manifests/master/routes.pp
@@ -22,7 +22,7 @@ class puppetdb::master::routes (
   } elsif $routes {
     $routes_real = $routes
   } else {
-    if (defined('$serverversion')) and (versioncmp($serverversion, '7.0') >= 0) {
+    if (defined('$clientversion')) and (versioncmp($clientversion, '7.0') >= 0) {
       $default_fact_cache = 'json'
     } else {
       $default_fact_cache = 'yaml'


### PR DESCRIPTION
With the change introduced in puppetlabs/puppetlabs-puppetdb#312 this
module switches the fact cache type if the puppetserver it's running
against is v7 or greater; in that situation it will use the puppetserver
v7 default of `json` for the fact cache format.

Unfortunately this opens up the possibility that while the server a
puppet-agent is running against might be v7, the agent and the server it's
running to configure might not be. Specifically, we hit a situation
where a server hosting puppetserver 5 was running puppet-agent against
another puppetserver on version 7 (this was for the purposes of a
version rollout), with the result that this module configured the
puppetserver v5 with a fact cache format of `json`, signalling the
puppetserver v5 to restart and meaning it failed during startup.

I think the intention of the original change was to switch its behaviour
based on the version of puppetserver it's configuring, and not
necessarily the version of puppetserver it's running against. Given the
puppetserver compatibility requirements I believe it's safe to use the
puppet-agent version as an analogue for the local puppetserver version,
so here I'm using the `clientversion` fact to replace `serverversion`.