### PR TITLE
(maint) Add read-only user.

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,15 +608,15 @@ Which database backend to use for the read database. Only supports
 #### `read_database_host`
 *This parameter must be set to use another PuppetDB instance for queries.*
 
-The hostname or IP address of the read database server. If set to `undef`, 
-it will use the value of the `database_host` parameter. This option is
-supported in PuppetDB >= 1.6.
+The hostname or IP address of the read database server. If set to `undef`, and 
+`manage_database` is set to `true`, it will use the value of the `database_host` 
+parameter. This option is supported in PuppetDB >= 1.6.
 
 #### `read_database_port`
 
 The port that the read database server listens on. If `read_database_host`
-is set to `undef`, it will use the value of the `database_port` parameter. This
-option is supported in PuppetDB >= 1.6.
+is set to `undef`, and `manage_database` is set to `true`, it will use the value of 
+the `database_port` parameter. This option is supported in PuppetDB >= 1.6.
 
 #### `read_database_username`
 
@@ -637,8 +637,8 @@ Defaults to `true`
 #### `read_database_name`
 
 The name of the read database instance to connect to. If `read_database_host`
-is set to `undef`, it will use the value of the `database_name` parameter.
-This option is supported in PuppetDB >= 1.6.
+is set to `undef`, and `manage_database` is set to `true`, it will use the value of
+the `database_name` parameter. This option is supported in PuppetDB >= 1.6.
 
 #### `read_log_slow_statements`
 

--- a/README.md
+++ b/README.md
@@ -606,25 +606,26 @@ Which database backend to use for the read database. Only supports
 `postgres` (default). This option is supported in PuppetDB >= 1.6.
 
 #### `read_database_host`
-*This parameter must be set to enable the PuppetDB read-database.*
+*This parameter must be set to use another PuppetDB instance for queries.*
 
-The hostname or IP address of the read database server. Defaults to `undef`.
-The default is to use the regular database for reads and writes. This option is
+The hostname or IP address of the read database server. If set to `undef`, 
+it will use the value of the `database_host` parameter. This option is
 supported in PuppetDB >= 1.6.
 
 #### `read_database_port`
 
-The port that the read database server listens on. Defaults to `5432`. This
+The port that the read database server listens on. If `read_database_host`
+is set to `undef`, it will use the value of the `database_port` parameter. This
 option is supported in PuppetDB >= 1.6.
 
 #### `read_database_username`
 
-The name of the read database user to connect as. Defaults to `puppetdb`. This
+The name of the read database user to connect as. Defaults to `puppetdb-read`. This
 option is supported in PuppetDB >= 1.6.
 
 #### `read_database_password`
 
-The password for the read database user. Defaults to `puppetdb`. This option is
+The password for the read database user. Defaults to `puppetdb-read`. This option is
 supported in PuppetDB >= 1.6.
 
 #### `manage_read_db_password`
@@ -635,7 +636,8 @@ Defaults to `true`
 
 #### `read_database_name`
 
-The name of the read database instance to connect to. Defaults to `puppetdb`.
+The name of the read database instance to connect to. If `read_database_host`
+is set to `undef`, it will use the value of the `database_name` parameter.
 This option is supported in PuppetDB >= 1.6.
 
 #### `read_log_slow_statements`

--- a/manifests/database/default_read_grant.pp
+++ b/manifests/database/default_read_grant.pp
@@ -1,0 +1,59 @@
+# Private class. Grant read permissions to $database_read_only_username by default, for new tables created by
+# $database_username.
+define puppetdb::database::default_read_grant(
+  String $database_name,
+  String $schema,
+  String $database_username,
+  String $database_read_only_username,
+) {
+  postgresql_psql {"grant default select permission for ${database_read_only_username}":
+    db      => $database_name,
+    command => "ALTER DEFAULT PRIVILEGES
+                  FOR USER \"${database_username}\"
+                  IN SCHEMA \"${schema}\"
+                GRANT SELECT ON TABLES
+                  TO \"${database_read_only_username}\"",
+    unless  => "SELECT
+                  ns.nspname,
+                  acl.defaclobjtype,
+                  acl.defaclacl
+                FROM pg_default_acl acl
+                JOIN pg_namespace ns ON acl.defaclnamespace=ns.oid
+                WHERE acl.defaclacl::text ~ '.*\\\\\"${database_read_only_username}\\\\\"=r/${database_username}\\\".*'
+                AND nspname = '${schema}'",
+  }
+
+  postgresql_psql {"grant default usage permission for ${database_read_only_username}":
+    db      => $database_name,
+    command => "ALTER DEFAULT PRIVILEGES
+                  FOR USER \"${database_username}\"
+                  IN SCHEMA \"${schema}\"
+                GRANT USAGE ON SEQUENCES
+                  TO \"${database_read_only_username}\"",
+    unless  => "SELECT
+                  ns.nspname,
+                  acl.defaclobjtype,
+                  acl.defaclacl
+                FROM pg_default_acl acl
+                JOIN pg_namespace ns ON acl.defaclnamespace=ns.oid
+                WHERE acl.defaclacl::text ~ '.*\\\\\"${database_read_only_username}\\\\\"=U/${database_username}\\\".*'
+                AND nspname = '${schema}'",
+  }
+
+  postgresql_psql {"grant default execute permission for ${database_read_only_username}":
+    db      => $database_name,
+    command => "ALTER DEFAULT PRIVILEGES
+                  FOR USER \"${database_username}\"
+                  IN SCHEMA \"${schema}\"
+                GRANT EXECUTE ON FUNCTIONS
+                  TO \"${database_read_only_username}\"",
+    unless  => "SELECT
+                  ns.nspname,
+                  acl.defaclobjtype,
+                  acl.defaclacl
+                FROM pg_default_acl acl
+                JOIN pg_namespace ns ON acl.defaclnamespace=ns.oid
+                WHERE acl.defaclacl::text ~ '.*\\\\\"${database_read_only_username}\\\\\"=X/${database_username}\\\".*'
+                AND nspname = '${schema}'",
+  }
+}

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -16,7 +16,8 @@ class puppetdb::database::postgresql (
   $postgresql_ssl_cert_path    = $puppetdb::params::postgresql_ssl_cert_path,
   $postgresql_ssl_ca_cert_path = $puppetdb::params::postgresql_ssl_ca_cert_path,
   $read_database_username      = $puppetdb::params::read_database_username,
-  $read_database_password      = $puppetdb::params::read_database_password
+  $read_database_password      = $puppetdb::params::read_database_password,
+  $read_database_host          = $puppetdb::params::read_database_host
 ) inherits puppetdb::params {
 
   if $manage_server {
@@ -31,6 +32,15 @@ class puppetdb::database::postgresql (
       port                    => scanf($database_port, '%i')[0],
     }
 
+    # We need to create the ssl connection for the read user, when
+    # manage_database is set to true, or when read_database_host is defined.
+    # Otherwise we don't create it.
+    if $manage_database or $read_database_host != undef{
+      $create_read_user_rule = true
+    } else {
+      $create_read_user_rule = false
+    }
+
     # configure PostgreSQL communication with Puppet Agent SSL certificates if
     # postgresql_ssl_on is set to true
     if $postgresql_ssl_on {
@@ -41,7 +51,8 @@ class puppetdb::database::postgresql (
         puppetdb_server             => $puppetdb_server,
         postgresql_ssl_key_path     => $postgresql_ssl_key_path,
         postgresql_ssl_cert_path    => $postgresql_ssl_cert_path,
-        postgresql_ssl_ca_cert_path => $postgresql_ssl_ca_cert_path
+        postgresql_ssl_ca_cert_path => $postgresql_ssl_ca_cert_path,
+        create_read_user_rule       => $create_read_user_rule
       }
     }
 

--- a/manifests/database/postgresql_ssl_rules.pp
+++ b/manifests/database/postgresql_ssl_rules.pp
@@ -1,0 +1,34 @@
+# Private class for configuring the pg_ident.conf and pg_hba.conf files
+define puppetdb::database::postgresql_ssl_rules (
+  String $database_name,
+  String $database_username,
+  String $puppetdb_server,
+) {
+  $identity_map_key = "${database_name}-${database_username}-map"
+
+  postgresql::server::pg_hba_rule { "Allow certificate mapped connections to ${database_name} as ${database_username} (ipv4)":
+    type        => 'hostssl',
+    database    => $database_name,
+    user        => $database_username,
+    address     => '0.0.0.0/0',
+    auth_method => 'cert',
+    order       => 0,
+    auth_option => "map=${identity_map_key} clientcert=1"
+  }
+
+  postgresql::server::pg_hba_rule { "Allow certificate mapped connections to ${database_name} as ${database_username} (ipv6)":
+    type        => 'hostssl',
+    database    => $database_name,
+    user        => $database_username,
+    address     => '::0/0',
+    auth_method => 'cert',
+    order       => 0,
+    auth_option => "map=${identity_map_key} clientcert=1"
+  }
+
+  postgresql::server::pg_ident_rule { "Map the SSL certificate of the server as a ${database_username} user":
+    map_name          => $identity_map_key,
+    system_username   => $puppetdb_server,
+    database_username => $database_username,
+  }
+}

--- a/manifests/database/read_grant.pp
+++ b/manifests/database/read_grant.pp
@@ -1,0 +1,50 @@
+# Private class. Grant read-only permissions to $database_read_only_username for all objects in $schema of
+# $database_name
+define puppetdb::database::read_grant (
+  String $database_name,
+  String $schema,
+  String $database_read_only_username,
+) {
+  postgresql_psql { "grant select permission for ${database_read_only_username}":
+    db      => $database_name,
+    command => "GRANT SELECT
+                ON ALL TABLES IN SCHEMA \"${schema}\"
+                TO \"${database_read_only_username}\"",
+    unless  => "SELECT * FROM (
+                  SELECT COUNT(*)
+                  FROM pg_tables
+                  WHERE schemaname='public'
+                    AND has_table_privilege('${database_read_only_username}', schemaname || '.' || tablename, 'SELECT')=false
+                ) x
+                WHERE x.count=0",
+  }
+
+  postgresql_psql { "grant usage permission for ${database_read_only_username}":
+    db      => $database_name,
+    command => "GRANT USAGE
+                ON ALL SEQUENCES IN SCHEMA \"${schema}\"
+                TO \"${database_read_only_username}\"",
+    unless  => "SELECT * FROM (
+                  SELECT COUNT(*)
+                  FROM information_schema.sequences
+                  WHERE sequence_schema='public'
+                    AND has_sequence_privilege('${database_read_only_username}', sequence_schema || '.' || sequence_name, 'USAGE')=false
+                ) x
+                WHERE x.count=0",
+  }
+
+  postgresql_psql { "grant execution permission for ${database_read_only_username}":
+    db      => $database_name,
+    command => "GRANT EXECUTE
+                ON ALL FUNCTIONS IN SCHEMA \"${schema}\"
+                TO \"${database_read_only_username}\"",
+    unless  => "SELECT * FROM (
+                  SELECT COUNT(*)
+                  FROM pg_catalog.pg_proc p
+                  LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+                  WHERE n.nspname='public'
+                    AND has_function_privilege('${database_read_only_username}', p.oid, 'EXECUTE')=false
+                ) x
+                WHERE x.count=0",
+  }
+}

--- a/manifests/database/read_only_user.pp
+++ b/manifests/database/read_only_user.pp
@@ -1,0 +1,44 @@
+# Private class
+# A define type to manage the creation of a read-only postgres users.
+# In particular, it manages the necessary grants to enable such a user
+# to have read-only access to any existing objects as well as changes
+# the default access privileges so read-only access is maintained when
+# new objects are created by the $database_owner
+#
+# @param database_read_only_username [String] The name of the postgres read only user.
+# @param database [String] The name of the database to grant access to.
+# @param database_owner [String] The user which owns the database (i.e. the migration user
+#        for the database).
+# @param password_hash [String] The value of $_database_password in app_database.
+
+define puppetdb::database::read_only_user (
+  String $read_database_username,
+  String $database_name,
+  String $database_owner,
+  Variant[String, Boolean] $password_hash = false,
+) {
+  postgresql::server::role { $read_database_username:
+    password_hash => $password_hash,
+  }
+
+  -> postgresql::server::database_grant { "${database_name} grant connection permission to ${read_database_username}":
+    privilege => 'CONNECT',
+    db        => $database_name,
+    role      => $read_database_username,
+  }
+
+  -> puppetdb::database::default_read_grant {
+    "${database_name} grant read permission on new objects from ${database_owner} to ${read_database_username}":
+      database_username           => $database_owner,
+      database_read_only_username => $read_database_username,
+      database_name               => $database_name,
+      schema                      => 'public',
+  }
+
+  -> puppetdb::database::read_grant {
+    "${database_name} grant read-only permission on existing objects to ${read_database_username}":
+      database_read_only_username => $read_database_username,
+      database_name               => $database_name,
+      schema                      => 'public',
+  }
+}

--- a/manifests/database/ssl_configuration.pp
+++ b/manifests/database/ssl_configuration.pp
@@ -4,10 +4,12 @@ class puppetdb::database::ssl_configuration (
   $database_name               = $puppetdb::params::database_name,
   $database_username           = $puppetdb::params::database_username,
   $read_database_username      = $puppetdb::params::read_database_username,
+  $read_database_host          = $puppetdb::params::read_database_host,
   $puppetdb_server             = $puppetdb::params::puppetdb_server,
   $postgresql_ssl_key_path     = $puppetdb::params::postgresql_ssl_key_path,
   $postgresql_ssl_cert_path    = $puppetdb::params::postgresql_ssl_cert_path,
-  $postgresql_ssl_ca_cert_path = $puppetdb::params::postgresql_ssl_ca_cert_path
+  $postgresql_ssl_ca_cert_path = $puppetdb::params::postgresql_ssl_ca_cert_path,
+  $create_read_user_rule       = false,
 ) inherits puppetdb::params {
   File {
     ensure  => present,
@@ -56,9 +58,11 @@ class puppetdb::database::ssl_configuration (
     puppetdb_server   => $puppetdb_server,
   }
 
-  puppetdb::database::postgresql_ssl_rules { "Configure postgresql ssl rules for ${read_database_username}":
-    database_name     => $database_name,
-    database_username => $read_database_username,
-    puppetdb_server   => $puppetdb_server,
+  if $create_read_user_rule {
+    puppetdb::database::postgresql_ssl_rules { "Configure postgresql ssl rules for ${read_database_username}":
+      database_name     => $database_name,
+      database_username => $read_database_username,
+      puppetdb_server   => $puppetdb_server,
+    }
   }
 }

--- a/manifests/database/ssl_configuration.pp
+++ b/manifests/database/ssl_configuration.pp
@@ -1,81 +1,64 @@
 # Class for configuring SSL connection for the PuppetDB postgresql database. See README.md for more
 # information.
-class puppetdb::database::ssl_configuration(
+class puppetdb::database::ssl_configuration (
   $database_name               = $puppetdb::params::database_name,
   $database_username           = $puppetdb::params::database_username,
+  $read_database_username      = $puppetdb::params::read_database_username,
   $puppetdb_server             = $puppetdb::params::puppetdb_server,
   $postgresql_ssl_key_path     = $puppetdb::params::postgresql_ssl_key_path,
   $postgresql_ssl_cert_path    = $puppetdb::params::postgresql_ssl_cert_path,
   $postgresql_ssl_ca_cert_path = $puppetdb::params::postgresql_ssl_ca_cert_path
 ) inherits puppetdb::params {
-
-  file {'postgres private key':
+  File {
     ensure  => present,
-    path    => "${postgresql::server::datadir}/server.key",
-    source  => $postgresql_ssl_key_path,
     owner   => 'postgres',
     mode    => '0600',
     require => Package['postgresql-server'],
   }
 
-  file {'postgres public key':
-    ensure  => present,
-    path    => "${postgresql::server::datadir}/server.crt",
-    source  => $postgresql_ssl_cert_path,
-    owner   => 'postgres',
-    mode    => '0600',
-    require => Package['postgresql-server'],
+  file { 'postgres private key':
+    path   => "${postgresql::server::datadir}/server.key",
+    source => $postgresql_ssl_key_path,
   }
 
-  postgresql::server::config_entry {'ssl':
+  file { 'postgres public key':
+    path   => "${postgresql::server::datadir}/server.crt",
+    source => $postgresql_ssl_cert_path,
+  }
+
+  postgresql::server::config_entry { 'ssl':
     ensure  => present,
     value   => 'on',
     require => [File['postgres private key'], File['postgres public key']]
   }
 
-  postgresql::server::config_entry {'ssl_cert_file':
+  postgresql::server::config_entry { 'ssl_cert_file':
     ensure  => present,
     value   => "${postgresql::server::datadir}/server.crt",
     require => [File['postgres private key'], File['postgres public key']]
   }
 
-  postgresql::server::config_entry {'ssl_key_file':
+  postgresql::server::config_entry { 'ssl_key_file':
     ensure  => present,
     value   => "${postgresql::server::datadir}/server.key",
     require => [File['postgres private key'], File['postgres public key']]
   }
 
-  postgresql::server::config_entry {'ssl_ca_file':
+  postgresql::server::config_entry { 'ssl_ca_file':
     ensure  => present,
     value   => $postgresql_ssl_ca_cert_path,
     require => [File['postgres private key'], File['postgres public key']]
   }
 
-  $identity_map_key = "${database_name}-${database_username}-map"
-
-  postgresql::server::pg_hba_rule { "Allow certificate mapped connections to ${database_name} as ${database_username} (ipv4)":
-    type        => 'hostssl',
-    database    => $database_name,
-    user        => $database_username,
-    address     => '0.0.0.0/0',
-    auth_method => 'cert',
-    order       => 0,
-    auth_option => "map=${identity_map_key} clientcert=1"
-  }
-
-  postgresql::server::pg_hba_rule { "Allow certificate mapped connections to ${database_name} as ${database_username} (ipv6)":
-    type        => 'hostssl',
-    database    => $database_name,
-    user        => $database_username,
-    address     => '::0/0',
-    auth_method => 'cert',
-    order       => 0,
-    auth_option => "map=${identity_map_key} clientcert=1"
-  }
-
-  postgresql::server::pg_ident_rule {"Map the SSL certificate of the server as a ${database_username} user":
-    map_name          => $identity_map_key,
-    system_username   => $puppetdb_server,
+  puppetdb::database::postgresql_ssl_rules { "Configure postgresql ssl rules for ${database_username}":
+    database_name     => $database_name,
     database_username => $database_username,
+    puppetdb_server   => $puppetdb_server,
+  }
+
+  puppetdb::database::postgresql_ssl_rules { "Configure postgresql ssl rules for ${read_database_username}":
+    database_name     => $database_name,
+    database_username => $read_database_username,
+    puppetdb_server   => $puppetdb_server,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -159,6 +159,7 @@ class puppetdb (
     puppetdb_user                     => $puppetdb_user,
     puppetdb_group                    => $puppetdb_group,
     manage_firewall                   => $manage_firewall,
+    manage_database                   => $manage_database,
     command_threads                   => $command_threads,
     concurrent_writes                 => $concurrent_writes,
     store_usage                       => $store_usage,
@@ -183,18 +184,23 @@ class puppetdb (
     }
 
     class { '::puppetdb::database::postgresql':
-      listen_addresses    => $database_listen_address,
-      database_name       => $database_name,
-      puppetdb_server     => $puppetdb_server,
-      database_username   => $database_username,
-      database_password   => $database_password,
-      database_port       => $database_port,
-      manage_server       => $manage_dbserver,
-      manage_database     => $manage_database,
-      manage_package_repo => $manage_package_repo,
-      postgres_version    => $postgres_version,
-      postgresql_ssl_on   => $postgresql_ssl_on,
-      before              => $database_before
+      listen_addresses            => $database_listen_address,
+      database_name               => $database_name,
+      puppetdb_server             => $puppetdb_server,
+      database_username           => $database_username,
+      database_password           => $database_password,
+      database_port               => $database_port,
+      manage_server               => $manage_dbserver,
+      manage_database             => $manage_database,
+      manage_package_repo         => $manage_package_repo,
+      postgres_version            => $postgres_version,
+      postgresql_ssl_on           => $postgresql_ssl_on,
+      postgresql_ssl_key_path     => $postgresql_ssl_key_path,
+      postgresql_ssl_cert_path    => $postgresql_ssl_cert_path,
+      postgresql_ssl_ca_cert_path => $postgresql_ssl_ca_cert_path,
+      read_database_username      => $read_database_username,
+      read_database_password      => $read_database_password,
+      before                      => $database_before
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -200,6 +200,7 @@ class puppetdb (
       postgresql_ssl_ca_cert_path => $postgresql_ssl_ca_cert_path,
       read_database_username      => $read_database_username,
       read_database_password      => $read_database_password,
+      read_database_host          => $read_database_host,
       before                      => $database_before
     }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,8 +61,8 @@ class puppetdb::params inherits puppetdb::globals {
   $read_database_host                = undef
   $read_database_port                = '5432'
   $read_database_name                = 'puppetdb'
-  $read_database_username            = 'puppetdb'
-  $read_database_password            = 'puppetdb'
+  $read_database_username            = 'puppetdb-read'
+  $read_database_password            = 'puppetdb-read'
   $manage_read_db_password           = true
   $read_database_jdbc_ssl_properties = ''
   $read_database_validate            = true

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -1,34 +1,34 @@
 # PRIVATE CLASS - do not use directly
 class puppetdb::server::database (
-  $database               = $puppetdb::params::database,
-  $database_host          = $puppetdb::params::database_host,
-  $database_port          = $puppetdb::params::database_port,
-  $database_username      = $puppetdb::params::database_username,
-  $database_password      = $puppetdb::params::database_password,
-  $database_name          = $puppetdb::params::database_name,
-  $manage_db_password     = $puppetdb::params::manage_db_password,
-  $jdbc_ssl_properties    = $puppetdb::params::jdbc_ssl_properties,
-  $database_validate      = $puppetdb::params::database_validate,
-  $database_embedded_path = $puppetdb::params::database_embedded_path,
-  $node_ttl               = $puppetdb::params::node_ttl,
-  $node_purge_ttl         = $puppetdb::params::node_purge_ttl,
-  $report_ttl             = $puppetdb::params::report_ttl,
-  $facts_blacklist        = $puppetdb::params::facts_blacklist,
-  $gc_interval            = $puppetdb::params::gc_interval,
-  $node_purge_gc_batch_limit  = $puppetdb::params::node_purge_gc_batch_limit,
-  $log_slow_statements    = $puppetdb::params::log_slow_statements,
-  $conn_max_age           = $puppetdb::params::conn_max_age,
-  $conn_keep_alive        = $puppetdb::params::conn_keep_alive,
-  $conn_lifetime          = $puppetdb::params::conn_lifetime,
-  $confdir                = $puppetdb::params::confdir,
-  $puppetdb_user          = $puppetdb::params::puppetdb_user,
-  $puppetdb_group         = $puppetdb::params::puppetdb_group,
-  $database_max_pool_size = $puppetdb::params::database_max_pool_size,
-  $migrate                = $puppetdb::params::migrate,
-  $postgresql_ssl_on      = $puppetdb::params::postgresql_ssl_on,
-  $ssl_cert_path          = $puppetdb::params::ssl_cert_path,
-  $ssl_key_pk8_path       = $puppetdb::params::ssl_key_pk8_path,
-  $ssl_ca_cert_path       = $puppetdb::params::ssl_ca_cert_path
+  $database                  = $puppetdb::params::database,
+  $database_host             = $puppetdb::params::database_host,
+  $database_port             = $puppetdb::params::database_port,
+  $database_username         = $puppetdb::params::database_username,
+  $database_password         = $puppetdb::params::database_password,
+  $database_name             = $puppetdb::params::database_name,
+  $manage_db_password        = $puppetdb::params::manage_db_password,
+  $jdbc_ssl_properties       = $puppetdb::params::jdbc_ssl_properties,
+  $database_validate         = $puppetdb::params::database_validate,
+  $database_embedded_path    = $puppetdb::params::database_embedded_path,
+  $node_ttl                  = $puppetdb::params::node_ttl,
+  $node_purge_ttl            = $puppetdb::params::node_purge_ttl,
+  $report_ttl                = $puppetdb::params::report_ttl,
+  $facts_blacklist           = $puppetdb::params::facts_blacklist,
+  $gc_interval               = $puppetdb::params::gc_interval,
+  $node_purge_gc_batch_limit = $puppetdb::params::node_purge_gc_batch_limit,
+  $log_slow_statements       = $puppetdb::params::log_slow_statements,
+  $conn_max_age              = $puppetdb::params::conn_max_age,
+  $conn_keep_alive           = $puppetdb::params::conn_keep_alive,
+  $conn_lifetime             = $puppetdb::params::conn_lifetime,
+  $confdir                   = $puppetdb::params::confdir,
+  $puppetdb_user             = $puppetdb::params::puppetdb_user,
+  $puppetdb_group            = $puppetdb::params::puppetdb_group,
+  $database_max_pool_size    = $puppetdb::params::database_max_pool_size,
+  $migrate                   = $puppetdb::params::migrate,
+  $postgresql_ssl_on         = $puppetdb::params::postgresql_ssl_on,
+  $ssl_cert_path             = $puppetdb::params::ssl_cert_path,
+  $ssl_key_pk8_path          = $puppetdb::params::ssl_key_pk8_path,
+  $ssl_ca_cert_path          = $puppetdb::params::ssl_ca_cert_path
 ) inherits puppetdb::params {
 
   if str2bool($database_validate) {
@@ -61,8 +61,8 @@ class puppetdb::server::database (
 
   $file_require = File[$database_ini]
   $ini_setting_require = str2bool($database_validate) ? {
-    false => $file_require,
-    default  => [$file_require, Class['puppetdb::server::validate_db']],
+    false   => $file_require,
+    default => [$file_require, Class['puppetdb::server::validate_db']],
   }
   # Set the defaults
   Ini_setting {
@@ -74,9 +74,9 @@ class puppetdb::server::database (
 
   if $database == 'embedded' {
 
-    $classname   = 'org.hsqldb.jdbcDriver'
+    $classname = 'org.hsqldb.jdbcDriver'
     $subprotocol = 'hsqldb'
-    $subname     = "file:${database_embedded_path};hsqldb.tx=mvcc;sql.syntax_pgs=true"
+    $subname = "file:${database_embedded_path};hsqldb.tx=mvcc;sql.syntax_pgs=true"
 
   } elsif $database == 'postgres' {
     $classname = 'org.postgresql.Driver'
@@ -108,13 +108,13 @@ class puppetdb::server::database (
     }
 
     ##Only setup for postgres
-    ini_setting {'puppetdb_psdatabase_username':
+    ini_setting { 'puppetdb_psdatabase_username':
       setting => 'username',
       value   => $database_username,
     }
 
     if $database_password != undef and $manage_db_password {
-      ini_setting {'puppetdb_psdatabase_password':
+      ini_setting { 'puppetdb_psdatabase_password':
         setting => 'password',
         value   => $database_password,
       }
@@ -217,5 +217,4 @@ class puppetdb::server::database (
       setting => 'facts-blacklist',
     }
   }
-
 }

--- a/manifests/server/read_database.pp
+++ b/manifests/server/read_database.pp
@@ -164,5 +164,9 @@ class puppetdb::server::read_database (
         ensure => absent,
       }
     }
+  } else {
+    file { "${confdir}/read_database.ini":
+      ensure => absent,
+    }
   }
 }

--- a/manifests/server/read_database.pp
+++ b/manifests/server/read_database.pp
@@ -1,11 +1,11 @@
 # PRIVATE CLASS - do not use directly
 class puppetdb::server::read_database (
-  $database               = $puppetdb::params::read_database,
-  $database_host          = $puppetdb::params::read_database_host,
-  $database_port          = $puppetdb::params::read_database_port,
-  $database_username      = $puppetdb::params::read_database_username,
-  $database_password      = $puppetdb::params::read_database_password,
-  $database_name          = $puppetdb::params::read_database_name,
+  $read_database          = $puppetdb::params::read_database,
+  $read_database_host     = $puppetdb::params::read_database_host,
+  $read_database_port     = $puppetdb::params::read_database_port,
+  $read_database_username = $puppetdb::params::read_database_username,
+  $read_database_password = $puppetdb::params::read_database_password,
+  $read_database_name     = $puppetdb::params::read_database_name,
   $manage_db_password     = $puppetdb::params::manage_read_db_password,
   $jdbc_ssl_properties    = $puppetdb::params::read_database_jdbc_ssl_properties,
   $database_validate      = $puppetdb::params::read_database_validate,
@@ -23,8 +23,7 @@ class puppetdb::server::read_database (
   $ssl_ca_cert_path       = $puppetdb::params::ssl_ca_cert_path
 ) inherits puppetdb::params {
 
-  # Only add the read database configuration if database host is defined.
-  if $database_host != undef {
+  if $read_database_host != undef {
     if str2bool($database_validate) {
       # Validate the database connection.  If we can't connect, we want to fail
       # and skip the rest of the configuration, so that we don't leave puppetdb
@@ -35,12 +34,12 @@ class puppetdb::server::read_database (
       # a duplicate declaration if read and write database host+name are the
       # same.
       class { 'puppetdb::server::validate_read_db':
-        database          => $database,
-        database_host     => $database_host,
-        database_port     => $database_port,
-        database_username => $database_username,
-        database_password => $database_password,
-        database_name     => $database_name,
+        database          => $read_database,
+        database_host     => $read_database_host,
+        database_port     => $read_database_port,
+        database_username => $read_database_username,
+        database_password => $read_database_password,
+        database_name     => $read_database_name,
       }
     }
 
@@ -66,7 +65,7 @@ class puppetdb::server::read_database (
       require => $ini_setting_require,
     }
 
-    if $database == 'postgres' {
+    if $read_database == 'postgres' {
       $classname = 'org.postgresql.Driver'
       $subprotocol = 'postgresql'
 
@@ -77,7 +76,7 @@ class puppetdb::server::read_database (
         $database_suffix = ''
       }
 
-      $subname_default = "//${database_host}:${database_port}/${database_name}${database_suffix}"
+      $subname_default = "//${read_database_host}:${read_database_port}/${read_database_name}${database_suffix}"
 
       if $postgresql_ssl_on and !empty($jdbc_ssl_properties)
       {
@@ -86,24 +85,24 @@ class puppetdb::server::read_database (
 
       if $postgresql_ssl_on {
         $subname = @("EOT"/L)
-          ${subname_default}?\
-          ssl=true&sslfactory=org.postgresql.ssl.LibPQFactory&\
-          sslmode=verify-full&sslrootcert=${ssl_ca_cert_path}&\
-          sslkey=${ssl_key_pk8_path}&sslcert=${ssl_cert_path}\
-          | EOT
+        ${subname_default}?\
+        ssl=true&sslfactory=org.postgresql.ssl.LibPQFactory&\
+        sslmode=verify-full&sslrootcert=${ssl_ca_cert_path}&\
+        sslkey=${ssl_key_pk8_path}&sslcert=${ssl_cert_path}\
+        | EOT
       } else {
         $subname = $subname_default
       }
 
       ini_setting { 'puppetdb_read_database_username':
         setting => 'username',
-        value   => $database_username,
+        value   => $read_database_username,
       }
 
-      if $database_password != undef and $manage_db_password {
+      if $read_database_password != undef and $manage_db_password {
         ini_setting { 'puppetdb_read_database_password':
           setting => 'password',
-          value   => $database_password,
+          value   => $read_database_password,
         }
       }
     }
@@ -160,10 +159,10 @@ class puppetdb::server::read_database (
           value   => $database_max_pool_size,
         }
       }
-    }
-  } else {
-    file { "${confdir}/read_database.ini":
-      ensure => absent,
+    } else {
+      file { "${confdir}/read_database.ini":
+        ensure => absent,
+      }
     }
   }
 }

--- a/spec/unit/classes/database/ssl_configuration_spec.rb
+++ b/spec/unit/classes/database/ssl_configuration_spec.rb
@@ -103,15 +103,8 @@ describe 'puppetdb::database::ssl_configuration', type: :class do
         .with_auth_option("map=#{identity_map} clientcert=1")
     end
 
-    it 'has hba rule for puppetdb-read user ipv4' do
-      is_expected.to contain_postgresql__server__pg_hba_rule("Allow certificate mapped connections to #{params[:database_name]} as #{params[:read_database_username]} (ipv4)")
-        .with_type('hostssl')
-        .with_database(params[:database_name])
-        .with_user(params[:read_database_username])
-        .with_address('0.0.0.0/0')
-        .with_auth_method('cert')
-        .with_order(0)
-        .with_auth_option("map=#{read_identity_map} clientcert=1")
+    it 'does not create hba rule for puppetdb-read user ipv4' do
+      is_expected.not_to contain_postgresql__server__pg_hba_rule("Allow certificate mapped connections to #{params[:database_name]} as #{params[:read_database_username]} (ipv4)")
     end
 
     it 'has hba rule for puppetdb user ipv6' do
@@ -125,15 +118,8 @@ describe 'puppetdb::database::ssl_configuration', type: :class do
         .with_auth_option("map=#{identity_map} clientcert=1")
     end
 
-    it 'has hba rule for puppetdb-read user ipv6' do
-      is_expected.to contain_postgresql__server__pg_hba_rule("Allow certificate mapped connections to #{params[:database_name]} as #{params[:read_database_username]} (ipv6)")
-        .with_type('hostssl')
-        .with_database(params[:database_name])
-        .with_user(params[:read_database_username])
-        .with_address('::0/0')
-        .with_auth_method('cert')
-        .with_order(0)
-        .with_auth_option("map=#{read_identity_map} clientcert=1")
+    it 'does not create hba rule for puppetdb-read user ipv6' do
+      is_expected.not_to contain_postgresql__server__pg_hba_rule("Allow certificate mapped connections to #{params[:database_name]} as #{params[:read_database_username]} (ipv6)")
     end
 
     it 'has ident rule' do
@@ -143,11 +129,8 @@ describe 'puppetdb::database::ssl_configuration', type: :class do
         .with_database_username(params[:database_name])
     end
 
-    it 'has read ident rule' do
-      is_expected.to contain_postgresql__server__pg_ident_rule("Map the SSL certificate of the server as a #{params[:read_database_username]} user")
-        .with_map_name(read_identity_map)
-        .with_system_username(facts[:fqdn])
-        .with_database_username(params[:read_database_username])
+    it 'does not create read ident rule' do
+      is_expected.not_to contain_postgresql__server__pg_ident_rule("Map the SSL certificate of the server as a #{params[:read_database_username]} user")
     end
 
     context 'when the puppetdb_server is set' do
@@ -164,6 +147,45 @@ describe 'puppetdb::database::ssl_configuration', type: :class do
           .with_map_name(identity_map)
           .with_system_username(params[:puppetdb_server])
           .with_database_username(params[:database_name])
+      end
+    end
+
+    context 'when the create_read_user_rule is set to true' do
+      let(:params) do
+        {
+          database_name: 'puppetdb',
+          read_database_username: 'puppetdb-read',
+          create_read_user_rule: true,
+        }
+      end
+
+      it 'has hba rule for puppetdb-read user ipv4' do
+        is_expected.to contain_postgresql__server__pg_hba_rule("Allow certificate mapped connections to #{params[:database_name]} as #{params[:read_database_username]} (ipv4)")
+          .with_type('hostssl')
+          .with_database(params[:database_name])
+          .with_user(params[:read_database_username])
+          .with_address('0.0.0.0/0')
+          .with_auth_method('cert')
+          .with_order(0)
+          .with_auth_option("map=#{read_identity_map} clientcert=1")
+      end
+
+      it 'has hba rule for puppetdb-read user ipv6' do
+        is_expected.to contain_postgresql__server__pg_hba_rule("Allow certificate mapped connections to #{params[:database_name]} as #{params[:read_database_username]} (ipv6)")
+          .with_type('hostssl')
+          .with_database(params[:database_name])
+          .with_user(params[:read_database_username])
+          .with_address('::0/0')
+          .with_auth_method('cert')
+          .with_order(0)
+          .with_auth_option("map=#{read_identity_map} clientcert=1")
+      end
+
+      it 'has read ident rule' do
+        is_expected.to contain_postgresql__server__pg_ident_rule("Map the SSL certificate of the server as a #{params[:read_database_username]} user")
+          .with_map_name(read_identity_map)
+          .with_system_username(facts[:fqdn])
+          .with_database_username(params[:read_database_username])
       end
     end
   end

--- a/spec/unit/classes/database/ssl_configuration_spec.rb
+++ b/spec/unit/classes/database/ssl_configuration_spec.rb
@@ -27,10 +27,12 @@ describe 'puppetdb::database::ssl_configuration', type: :class do
         postgresql_ssl_ca_cert_path: '/puppet/cert/ca.pem',
         database_name: 'puppetdb',
         database_username: 'puppetdb',
+        read_database_username: 'puppetdb-read',
       }
     end
 
     let(:identity_map) { "#{params[:database_name]}-#{params[:database_username]}-map" }
+    let(:read_identity_map) { "#{params[:database_name]}-#{params[:read_database_username]}-map" }
     let(:datadir_path) { '/var/lib/data' }
 
     let(:pre_condition) do
@@ -90,7 +92,7 @@ describe 'puppetdb::database::ssl_configuration', type: :class do
         .that_requires('File[postgres public key]')
     end
 
-    it 'has hba rule for ipv4' do
+    it 'has hba rule for puppetdb user ipv4' do
       is_expected.to contain_postgresql__server__pg_hba_rule("Allow certificate mapped connections to #{params[:database_name]} as #{params[:database_username]} (ipv4)")
         .with_type('hostssl')
         .with_database(params[:database_name])
@@ -101,7 +103,18 @@ describe 'puppetdb::database::ssl_configuration', type: :class do
         .with_auth_option("map=#{identity_map} clientcert=1")
     end
 
-    it 'has hba rule for ipv6' do
+    it 'has hba rule for puppetdb-read user ipv4' do
+      is_expected.to contain_postgresql__server__pg_hba_rule("Allow certificate mapped connections to #{params[:database_name]} as #{params[:read_database_username]} (ipv4)")
+        .with_type('hostssl')
+        .with_database(params[:database_name])
+        .with_user(params[:read_database_username])
+        .with_address('0.0.0.0/0')
+        .with_auth_method('cert')
+        .with_order(0)
+        .with_auth_option("map=#{read_identity_map} clientcert=1")
+    end
+
+    it 'has hba rule for puppetdb user ipv6' do
       is_expected.to contain_postgresql__server__pg_hba_rule("Allow certificate mapped connections to #{params[:database_name]} as #{params[:database_username]} (ipv6)")
         .with_type('hostssl')
         .with_database(params[:database_name])
@@ -112,11 +125,29 @@ describe 'puppetdb::database::ssl_configuration', type: :class do
         .with_auth_option("map=#{identity_map} clientcert=1")
     end
 
+    it 'has hba rule for puppetdb-read user ipv6' do
+      is_expected.to contain_postgresql__server__pg_hba_rule("Allow certificate mapped connections to #{params[:database_name]} as #{params[:read_database_username]} (ipv6)")
+        .with_type('hostssl')
+        .with_database(params[:database_name])
+        .with_user(params[:read_database_username])
+        .with_address('::0/0')
+        .with_auth_method('cert')
+        .with_order(0)
+        .with_auth_option("map=#{read_identity_map} clientcert=1")
+    end
+
     it 'has ident rule' do
       is_expected.to contain_postgresql__server__pg_ident_rule("Map the SSL certificate of the server as a #{params[:database_username]} user")
         .with_map_name(identity_map)
         .with_system_username(facts[:fqdn])
         .with_database_username(params[:database_name])
+    end
+
+    it 'has read ident rule' do
+      is_expected.to contain_postgresql__server__pg_ident_rule("Map the SSL certificate of the server as a #{params[:read_database_username]} user")
+        .with_map_name(read_identity_map)
+        .with_system_username(facts[:fqdn])
+        .with_database_username(params[:read_database_username])
     end
 
     context 'when the puppetdb_server is set' do

--- a/spec/unit/classes/server/db_read_uri_spec.rb
+++ b/spec/unit/classes/server/db_read_uri_spec.rb
@@ -14,7 +14,7 @@ describe 'puppetdb::server::read_database', type: :class do
     describe 'when passing jdbc subparams' do
       let(:params) do
         {
-          database_host: 'localhost',
+          read_database_host: 'localhost',
           jdbc_ssl_properties: '?ssl=true',
         }
       end
@@ -32,7 +32,7 @@ describe 'puppetdb::server::read_database', type: :class do
     describe 'when using ssl communication' do
       let(:params) do
         {
-          database_host: 'cheery-rime.puppetlabs.net',
+          read_database_host: 'cheery-rime.puppetlabs.net',
           postgresql_ssl_on: true,
           ssl_key_pk8_path: '/tmp/private_key.pk8',
         }
@@ -57,7 +57,7 @@ describe 'puppetdb::server::read_database', type: :class do
       context 'when setting jdbc_ssl_properties as well' do
         let(:params) do
           {
-            database_host: 'puppetdb',
+            read_database_host: 'puppetdb',
             jdbc_ssl_properties: '?ssl=true',
             postgresql_ssl_on: true,
           }

--- a/spec/unit/classes/server/read_database_ini_spec.rb
+++ b/spec/unit/classes/server/read_database_ini_spec.rb
@@ -15,7 +15,7 @@ describe 'puppetdb::server::read_database', type: :class do
     it { is_expected.to contain_class('puppetdb::server::read_database') }
 
     describe 'when using default values' do
-      it { is_expected.to contain_file('/etc/puppetlabs/puppetdb/conf.d/read_database.ini') }
+      it { is_expected.to contain_file('/etc/puppetlabs/puppetdb/conf.d/read_database.ini').with('ensure' => 'absent') }
     end
 
     describe 'when using minimum working values' do

--- a/spec/unit/classes/server/read_database_ini_spec.rb
+++ b/spec/unit/classes/server/read_database_ini_spec.rb
@@ -15,13 +15,13 @@ describe 'puppetdb::server::read_database', type: :class do
     it { is_expected.to contain_class('puppetdb::server::read_database') }
 
     describe 'when using default values' do
-      it { is_expected.to contain_file('/etc/puppetlabs/puppetdb/conf.d/read_database.ini').with('ensure' => 'absent') }
+      it { is_expected.to contain_file('/etc/puppetlabs/puppetdb/conf.d/read_database.ini') }
     end
 
     describe 'when using minimum working values' do
       let(:params) do
         {
-          'database_host' => 'puppetdb',
+          'read_database_host' => 'puppetdb',
         }
       end
 
@@ -41,7 +41,7 @@ describe 'puppetdb::server::read_database', type: :class do
             'path'    => '/etc/puppetlabs/puppetdb/conf.d/read_database.ini',
             'section' => 'read-database',
             'setting' => 'username',
-            'value'   => 'puppetdb',
+            'value'   => 'puppetdb-read',
           )
       }
       it {
@@ -51,7 +51,7 @@ describe 'puppetdb::server::read_database', type: :class do
             'path'    => '/etc/puppetlabs/puppetdb/conf.d/read_database.ini',
             'section' => 'read-database',
             'setting' => 'password',
-            'value'   => 'puppetdb',
+            'value'   => 'puppetdb-read',
           )
       }
       it {
@@ -128,7 +128,7 @@ describe 'puppetdb::server::read_database', type: :class do
       context 'when using ssl communication' do
         let(:params) do
           {
-            database_host: 'puppetdb',
+            read_database_host: 'puppetdb',
             postgresql_ssl_on: true,
             ssl_key_pk8_path: '/tmp/private_key.pk8',
           }
@@ -153,7 +153,7 @@ describe 'puppetdb::server::read_database', type: :class do
         context 'when setting jdbc_ssl_properties as well' do
           let(:params) do
             {
-              database_host: 'puppetdb',
+              read_database_host: 'puppetdb',
               jdbc_ssl_properties: '?ssl=true',
               postgresql_ssl_on: true,
             }


### PR DESCRIPTION
There used to be only one user (puppetdb) which was used for all operations on the database.
This PR adds a read only user in PostgreSQL which will be used only for queries. 