### PR TITLE
Fix minimum version of puppetlabs/postgresql

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/postgresql",
-      "version_requirement": ">= 4.0.0 < 8.0.0"
+      "version_requirement": ">= 6.5.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/firewall",


### PR DESCRIPTION
https://github.com/puppetlabs/puppetlabs-puppetdb/pull/330 uses the
namespaced `postgresql::postgresql_password` function that wasn't
available until 6.5.0.

(Even before that PR, I doubt this module worked with
puppetlabs/postgresql 4.0.0 released in 2014).