### PR TITLE
fix: Syntax error: Unterminated quoted string

### DIFF
--- a/manifests/database/default_read_grant.pp
+++ b/manifests/database/default_read_grant.pp
@@ -19,7 +19,7 @@ define puppetdb::database::default_read_grant(
                   acl.defaclacl
                 FROM pg_default_acl acl
                 JOIN pg_namespace ns ON acl.defaclnamespace=ns.oid
-                WHERE acl.defaclacl::text ~ '.*\\\\\"${database_read_only_username}\\\\\"=r/${database_username}\\\".*'
+                WHERE acl.defaclacl::text ~ '.*\\\\\"${database_read_only_username}\\\\\"=r/${database_username}\\\\\".*'
                 AND nspname = '${schema}'",
   }
 
@@ -36,7 +36,7 @@ define puppetdb::database::default_read_grant(
                   acl.defaclacl
                 FROM pg_default_acl acl
                 JOIN pg_namespace ns ON acl.defaclnamespace=ns.oid
-                WHERE acl.defaclacl::text ~ '.*\\\\\"${database_read_only_username}\\\\\"=U/${database_username}\\\".*'
+                WHERE acl.defaclacl::text ~ '.*\\\\\"${database_read_only_username}\\\\\"=U/${database_username}\\\\\".*'
                 AND nspname = '${schema}'",
   }
 
@@ -53,7 +53,7 @@ define puppetdb::database::default_read_grant(
                   acl.defaclacl
                 FROM pg_default_acl acl
                 JOIN pg_namespace ns ON acl.defaclnamespace=ns.oid
-                WHERE acl.defaclacl::text ~ '.*\\\\\"${database_read_only_username}\\\\\"=X/${database_username}\\\".*'
+                WHERE acl.defaclacl::text ~ '.*\\\\\"${database_read_only_username}\\\\\"=X/${database_username}\\\\\".*'
                 AND nspname = '${schema}'",
   }
 }


### PR DESCRIPTION
I've got the same error as @waipeng reported here in https://github.com/puppetlabs/puppetlabs-puppetdb/pull/330#issuecomment-935496488. This MR fixes the unterminated quotes string issue in the unless clause.

I use the `manage_database` param without letting the module manage postgres itself.

```
Debug: Executing with uid=postgres gid=postgres: 'psql -d puppetdb -t -X -c "SELECT COUNT(*) FROM (SELECT
                  ns.nspname,
                  acl.defaclobjtype,
                  acl.defaclacl
                FROM pg_default_acl acl
                JOIN pg_namespace ns ON acl.defaclnamespace=ns.oid
                WHERE acl.defaclacl::text ~ '.*\\\"puppetdb-read\\\"=r/puppetdb\\".*'
                AND nspname = 'public') count"'
Error: /Stage[main]/Puppetdb::Database::Postgresql/Puppetdb::Database::Read_only_user[puppetdb-read]/Puppetdb::Database::Default_read_grant[puppetdb grant read permission on new objects from puppetdb to puppetdb-read]/Postgresql_psql[grant defa
ult select permission for puppetdb-read]: Could not evaluate: Error evaluating 'unless' clause, returned pid 31435 exit 2: 'sh: 8: Syntax error: Unterminated quoted string
'
Debug: Executing with uid=postgres gid=postgres: 'psql -d puppetdb -t -X -c "SELECT COUNT(*) FROM (SELECT
                  ns.nspname,
                  acl.defaclobjtype,
                  acl.defaclacl
                FROM pg_default_acl acl
                JOIN pg_namespace ns ON acl.defaclnamespace=ns.oid
                WHERE acl.defaclacl::text ~ '.*\\\"puppetdb-read\\\"=U/puppetdb\\".*'
                AND nspname = 'public') count"'
Error: /Stage[main]/Puppetdb::Database::Postgresql/Puppetdb::Database::Read_only_user[puppetdb-read]/Puppetdb::Database::Default_read_grant[puppetdb grant read permission on new objects from puppetdb to puppetdb-read]/Postgresql_psql[grant defa
ult usage permission for puppetdb-read]: Could not evaluate: Error evaluating 'unless' clause, returned pid 31438 exit 2: 'sh: 8: Syntax error: Unterminated quoted string
'
Debug: Executing with uid=postgres gid=postgres: 'psql -d puppetdb -t -X -c "SELECT COUNT(*) FROM (SELECT
                  ns.nspname,
                  acl.defaclobjtype,
                  acl.defaclacl
                FROM pg_default_acl acl
                JOIN pg_namespace ns ON acl.defaclnamespace=ns.oid
                WHERE acl.defaclacl::text ~ '.*\\\"puppetdb-read\\\"=X/puppetdb\\".*'
                AND nspname = 'public') count"'
Error: /Stage[main]/Puppetdb::Database::Postgresql/Puppetdb::Database::Read_only_user[puppetdb-read]/Puppetdb::Database::Default_read_grant[puppetdb grant read permission on new objects from puppetdb to puppetdb-read]/Postgresql_psql[grant defa
ult execute permission for puppetdb-read]: Could not evaluate: Error evaluating 'unless' clause, returned pid 31441 exit 2: 'sh: 8: Syntax error: Unterminated quoted string
'
```