### PR TITLE
Restrict configuration file permissions

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -478,7 +478,6 @@ class puppetdb::server (
     conn_max_age              => $conn_max_age,
     conn_lifetime             => $conn_lifetime,
     confdir                   => $confdir,
-    puppetdb_user             => $puppetdb_user,
     puppetdb_group            => $puppetdb_group,
     migrate                   => $migrate,
     notify                    => Service[$puppetdb_service],
@@ -510,7 +509,6 @@ class puppetdb::server (
     conn_max_age           => $read_conn_max_age,
     conn_lifetime          => $read_conn_lifetime,
     confdir                => $confdir,
-    puppetdb_user          => $puppetdb_user,
     puppetdb_group         => $puppetdb_group,
     notify                 => Service[$puppetdb_service],
     database_max_pool_size => $read_database_max_pool_size,
@@ -520,29 +518,29 @@ class puppetdb::server (
     file {
       $ssl_dir:
         ensure => directory,
-        owner  => $puppetdb_user,
+        owner  => 'root',
         group  => $puppetdb_group,
-        mode   => '0700';
+        mode   => '0755';
       $ssl_key_path:
         ensure  => file,
         content => $ssl_key,
-        owner   => $puppetdb_user,
+        owner   => 'root',
         group   => $puppetdb_group,
-        mode    => '0600',
+        mode    => '0640',
         notify  => Service[$puppetdb_service];
       $ssl_cert_path:
         ensure  => file,
         content => $ssl_cert,
-        owner   => $puppetdb_user,
+        owner   => 'root',
         group   => $puppetdb_group,
-        mode    => '0600',
+        mode    => '0644',
         notify  => Service[$puppetdb_service];
       $ssl_ca_cert_path:
         ensure  => file,
         content => $ssl_ca_cert,
-        owner   => $puppetdb_user,
+        owner   => 'root',
         group   => $puppetdb_group,
-        mode    => '0600',
+        mode    => '0644',
         notify  => Service[$puppetdb_service];
     }
   }
@@ -560,9 +558,9 @@ class puppetdb::server (
 
     file { $ssl_key_pk8_path:
       ensure => file,
-      owner  => $puppetdb_user,
+      owner  => 'root',
       group  => $puppetdb_group,
-      mode   => '0600',
+      mode   => '0640',
       notify => Service[$puppetdb_service],
     }
   }
@@ -583,7 +581,6 @@ class puppetdb::server (
     confdir            => $confdir,
     max_threads        => $max_threads,
     notify             => Service[$puppetdb_service],
-    puppetdb_user      => $puppetdb_user,
     puppetdb_group     => $puppetdb_group,
   }
 
@@ -592,7 +589,6 @@ class puppetdb::server (
     certificate_whitelist      => $certificate_whitelist,
     disable_update_checking    => $disable_update_checking,
     confdir                    => $confdir,
-    puppetdb_user              => $puppetdb_user,
     puppetdb_group             => $puppetdb_group,
     notify                     => Service[$puppetdb_service],
   }

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -19,7 +19,6 @@ class puppetdb::server::database (
   $conn_max_age              = $puppetdb::params::conn_max_age,
   $conn_lifetime             = $puppetdb::params::conn_lifetime,
   $confdir                   = $puppetdb::params::confdir,
-  $puppetdb_user             = $puppetdb::params::puppetdb_user,
   $puppetdb_group            = $puppetdb::params::puppetdb_group,
   $database_max_pool_size    = $puppetdb::params::database_max_pool_size,
   $migrate                   = $puppetdb::params::migrate,
@@ -50,9 +49,9 @@ class puppetdb::server::database (
 
   file { $database_ini:
     ensure => file,
-    owner  => $puppetdb_user,
+    owner  => 'root',
     group  => $puppetdb_group,
-    mode   => '0600',
+    mode   => '0640',
   }
 
   $file_require = File[$database_ini]

--- a/manifests/server/jetty.pp
+++ b/manifests/server/jetty.pp
@@ -16,16 +16,15 @@ class puppetdb::server::jetty (
   Optional[String] $cipher_suites = $puppetdb::params::cipher_suites,
   $confdir                        = $puppetdb::params::confdir,
   $max_threads                    = $puppetdb::params::max_threads,
-  $puppetdb_user                  = $puppetdb::params::puppetdb_user,
   $puppetdb_group                 = $puppetdb::params::puppetdb_group,
 ) inherits puppetdb::params {
   $jetty_ini = "${confdir}/jetty.ini"
 
   file { $jetty_ini:
     ensure => file,
-    owner  => $puppetdb_user,
+    owner  => 'root',
     group  => $puppetdb_group,
-    mode   => '0600',
+    mode   => '0640',
   }
 
   # Set the defaults

--- a/manifests/server/puppetdb.pp
+++ b/manifests/server/puppetdb.pp
@@ -6,16 +6,15 @@ class puppetdb::server::puppetdb (
   $certificate_whitelist      = $puppetdb::params::certificate_whitelist,
   $disable_update_checking    = $puppetdb::params::disable_update_checking,
   $confdir                    = $puppetdb::params::confdir,
-  $puppetdb_user              = $puppetdb::params::puppetdb_user,
   $puppetdb_group             = $puppetdb::params::puppetdb_group,
 ) inherits puppetdb::params {
   $puppetdb_ini = "${confdir}/puppetdb.ini"
 
   file { $puppetdb_ini:
     ensure => file,
-    owner  => $puppetdb_user,
+    owner  => 'root',
     group  => $puppetdb_group,
-    mode   => '0600',
+    mode   => '0640',
   }
 
   # Set the defaults

--- a/manifests/server/read_database.pp
+++ b/manifests/server/read_database.pp
@@ -13,7 +13,6 @@ class puppetdb::server::read_database (
   $conn_max_age           = $puppetdb::params::read_conn_max_age,
   $conn_lifetime          = $puppetdb::params::read_conn_lifetime,
   $confdir                = $puppetdb::params::confdir,
-  $puppetdb_user          = $puppetdb::params::puppetdb_user,
   $puppetdb_group         = $puppetdb::params::puppetdb_group,
   $database_max_pool_size = $puppetdb::params::read_database_max_pool_size,
   $postgresql_ssl_on      = $puppetdb::params::postgresql_ssl_on,
@@ -44,9 +43,9 @@ class puppetdb::server::read_database (
 
     file { $read_database_ini:
       ensure => file,
-      owner  => $puppetdb_user,
+      owner  => 'root',
       group  => $puppetdb_group,
-      mode   => '0600',
+      mode   => '0640',
     }
 
     $file_require = File[$read_database_ini]

--- a/spec/unit/classes/server/database_ini_spec.rb
+++ b/spec/unit/classes/server/database_ini_spec.rb
@@ -20,9 +20,9 @@ describe 'puppetdb::server::database', type: :class do
         is_expected.to contain_file("#{pdbconfdir}/database.ini")
           .with(
             'ensure'  => 'file',
-            'owner'   => 'puppetdb',
+            'owner'   => 'root',
             'group'   => 'puppetdb',
-            'mode'    => '0600',
+            'mode'    => '0640',
           )
       }
       it {

--- a/spec/unit/classes/server/jetty_ini_spec.rb
+++ b/spec/unit/classes/server/jetty_ini_spec.rb
@@ -20,9 +20,9 @@ describe 'puppetdb::server::jetty', type: :class do
         is_expected.to contain_file("#{pdbconfdir}/jetty.ini")
           .with(
             'ensure'  => 'file',
-            'owner'   => 'puppetdb',
+            'owner'   => 'root',
             'group'   => 'puppetdb',
-            'mode'    => '0600',
+            'mode'    => '0640',
           )
       }
       it {

--- a/spec/unit/classes/server/puppetdb_ini_spec.rb
+++ b/spec/unit/classes/server/puppetdb_ini_spec.rb
@@ -30,9 +30,9 @@ describe 'puppetdb::server::puppetdb', type: :class do
       is_expected.to contain_file('/etc/puppetlabs/puppetdb/conf.d/puppetdb.ini')
         .with(
           'ensure'  => 'file',
-          'owner'   => 'puppetdb',
+          'owner'   => 'root',
           'group'   => 'puppetdb',
-          'mode'    => '0600',
+          'mode'    => '0640',
         )
     }
     it {

--- a/spec/unit/classes/server/read_database_ini_spec.rb
+++ b/spec/unit/classes/server/read_database_ini_spec.rb
@@ -20,9 +20,9 @@ describe 'puppetdb::server::read_database', type: :class do
       is_expected.to contain_file('/etc/puppetlabs/puppetdb/conf.d/read_database.ini')
         .with(
           'ensure'  => 'file',
-          'owner'   => 'puppetdb',
+          'owner'   => 'root',
           'group'   => 'puppetdb',
-          'mode'    => '0600',
+          'mode'    => '0640',
         )
     }
     it {

--- a/spec/unit/classes/server_spec.rb
+++ b/spec/unit/classes/server_spec.rb
@@ -210,9 +210,9 @@ describe 'puppetdb::server', type: :class do
             is_expected.to contain_file('/etc/puppetlabs/puppetdb/ssl/private.pk8')
               .with(
                 ensure: 'file',
-                owner: 'puppetdb',
+                owner: 'root',
                 group: 'puppetdb',
-                mode: '0600',
+                mode: '0640',
               )
           end
         end


### PR DESCRIPTION
PuppetDB runs as the puppetdb user.  This user must have read access to the various configuration files but does not need write access to them.

This ensure the service configuration cannot be unexpectedly changed by PuppetDB itself if some vulnerability allow random code execution, limiting the possibilities of exploitation and pivoting if such a vulnerability is found.

This is a companion PR to #342: the FreeBSD port insists on secure file permissions and will enforce them when the service start.  On next Puppet run, the module will consider it configuration drift and revert the previous less paranoid configuration and reload the service which will harden the files mode immediatly.  Rather than optionaly ignoning the files mode, it makes more sense to use an hardened configuration by default.
