### PR TITLE
postgresql version >=10 onwards does not require contrib package

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -59,8 +59,9 @@ class puppetdb::database::postgresql (
     # Only install pg_trgm extension, if database it is actually managed by the module
     if $manage_database {
 
-      # from postgresql version 10 onwards, this extension is no longer inside the contrib package, but is being bundled with the postgresql package itself
-      if (versioncmp($postgres_version, '10') < 0) {
+      # from postgresql version 10 onwards, this extension is no longer inside
+      # the contrib package, but is being bundled with the postgresql package itself
+      if versioncmp($postgres_version, '10') < 0 {
         # get the pg contrib to use pg_trgm extension
         include postgresql::server::contrib
       }

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -59,8 +59,11 @@ class puppetdb::database::postgresql (
     # Only install pg_trgm extension, if database it is actually managed by the module
     if $manage_database {
 
-      # get the pg contrib to use pg_trgm extension
-      class { '::postgresql::server::contrib': }
+      # from postgresql version 10 onwards, this extension is no longer inside the contrib package, but is being bundled with the postgresql package itself
+      if (versioncmp($postgres_version, '10') < 0) {
+        # get the pg contrib to use pg_trgm extension
+        include postgresql::server::contrib
+      }
 
       postgresql::server::extension { 'pg_trgm':
         database => $database_name,


### PR DESCRIPTION
Fix for https://tickets.puppetlabs.com/browse/PDB-5454

_Started a new PR (to avoid license issue)_