### PR TITLE
cater for multiple server_urls 

### DIFF
--- a/lib/puppet/util/puppetdb_validator.rb
+++ b/lib/puppet/util/puppetdb_validator.rb
@@ -25,25 +25,29 @@ class Puppet::Util::PuppetdbValidator
   end
 
   def valid_connection_new_client?
-    test_uri = URI("#{use_ssl ? 'https' : 'http'}://#{puppetdb_server}:#{puppetdb_port}#{test_path}")
-    begin
-      conn = Puppet.runtime[:http]
-      _response = conn.get(test_uri, headers: test_headers)
-      true
-    rescue Puppet::HTTP::ResponseError => e
-      log_error e.message, e.response.code
-      false
-    end
+    puppetdb_server.each { | server |
+      test_uri = URI("#{use_ssl ? 'https' : 'http'}://#{server}:#{puppetdb_port}#{test_path}")
+      begin
+        conn = Puppet.runtime[:http]
+        _response = conn.get(test_uri, headers: test_headers)
+        true
+      rescue Puppet::HTTP::ResponseError => e
+        log_error e.message, e.response.code
+        false
+      end
+    }
   end
 
   def valid_connection_old_client?
-    conn = Puppet::Network::HttpPool.http_instance(puppetdb_server, puppetdb_port, use_ssl)
-    response = conn.get(test_path, test_headers)
-    unless response.is_a?(Net::HTTPSuccess)
-      log_error(response.msg, response.code)
-      return false
-    end
-    true
+    puppetdb_server.each { | server |
+      conn = Puppet::Network::HttpPool.http_instance(server, puppetdb_port, use_ssl)
+      response = conn.get(test_path, test_headers)
+      unless response.is_a?(Net::HTTPSuccess)
+        log_error(response.msg, response.code)
+        return false
+      end
+      true
+    }
   end
 
   # Utility method; attempts to make an http/https connection to the puppetdb server.

--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -1,6 +1,6 @@
 # Manage puppet configuration. See README.md for more details.
 class puppetdb::master::config (
-  $puppetdb_server             = $::fqdn,
+  $puppetdb_servers            = $::fqdn,
   $puppetdb_port               = defined(Class['puppetdb']) ? {
     true    => $::puppetdb::disable_ssl ? {
       true => 8080,
@@ -71,7 +71,7 @@ class puppetdb::master::config (
     # *must* not perform the other configuration steps, or else
 
     $conn_puppetdb_server = $manage_config ? {
-      true    => $puppetdb_server,
+      true    => $puppetdb_servers,
       default => undef,
     }
     $conn_puppetdb_port = $manage_config ? {
@@ -157,7 +157,7 @@ class puppetdb::master::config (
     }
 
     class { 'puppetdb::master::puppetdb_conf':
-      server             => $puppetdb_server,
+      servers            => $puppetdb_servers,
       port               => $puppetdb_port,
       soft_write_failure => $puppetdb_soft_write_failure,
       puppet_confdir     => $puppet_confdir,

--- a/manifests/master/puppetdb_conf.pp
+++ b/manifests/master/puppetdb_conf.pp
@@ -1,7 +1,7 @@
 # Manage the puppetdb.conf file on the puppeet master. See README.md for more
 # details.
 class puppetdb::master::puppetdb_conf (
-  $server             = 'localhost',
+  $servers            = 'localhost',
   $port               = '8081',
   $soft_write_failure = $puppetdb::disable_ssl ? {
     true => true,
@@ -30,9 +30,11 @@ class puppetdb::master::puppetdb_conf (
       value   => $port,
     }
   } else {
+    $servers_url_string = $servers.map | $server | { "https://${server}:${port}"}.join(',')
+
     ini_setting { 'puppetdbserver_urls':
       setting => 'server_urls',
-      value   => "https://${server}:${port}/",
+      value   => $servers_url_string,
     }
   }
 

--- a/manifests/master/puppetdb_conf.pp
+++ b/manifests/master/puppetdb_conf.pp
@@ -30,7 +30,12 @@ class puppetdb::master::puppetdb_conf (
       value   => $port,
     }
   } else {
-    $servers_url_string = $servers.map | $server | { "https://${server}:${port}"}.join(',')
+
+    if is_array($puppetdb_server) {
+      $servers_url_string = $servers.map | $server | { "https://${server}:${port}"}.join(',')
+    } else {
+      $servers_url_string = "https://${server}:${port}/"
+    }
 
     ini_setting { 'puppetdbserver_urls':
       setting => 'server_urls',


### PR DESCRIPTION
Documentation at [puppet.com](https://puppet.com/docs/puppetdb/7/puppetdb_connection.html#server_urls) states that multiple server_urls can be specified

> You can use a comma-separated list of URLs if there are multiple PuppetDB instances available. A server_urls config that supports two PuppetDBs would look like:

`server_urls = https://puppetdb1.example.com:8081,https://puppetdb2.example.com:8081`

This MR changes the `puppet_server` String into an Array and runs .map on it to allow for multiple puppetdb servers to be specified