### PR TITLE
Update github URLs to remove unauthenticated git

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,14 +1,14 @@
 fixtures:
   repositories:
-    inifile: 'git://github.com/puppetlabs/puppetlabs-inifile.git'
-    stdlib: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
-    postgresql: 'git://github.com/puppetlabs/puppet-postgresql.git'
-    firewall: 'git://github.com/puppetlabs/puppetlabs-firewall.git'
-    apt: 'git://github.com/puppetlabs/puppetlabs-apt.git'
-    concat: 'git://github.com/puppetlabs/puppetlabs-concat.git'
-    file_concat: 'git://github.com/electrical/puppet-lib-file_concat.git'
-    systemd: 'git://github.com/camptocamp/puppet-systemd.git'
-    cron: 'git://github.com/voxpupuli/puppet-cron.git'
+    inifile: 'https://github.com/puppetlabs/puppetlabs-inifile.git'
+    stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
+    postgresql: 'https://github.com/puppetlabs/puppet-postgresql.git'
+    firewall: 'https://github.com/puppetlabs/puppetlabs-firewall.git'
+    apt: 'https://github.com/puppetlabs/puppetlabs-apt.git'
+    concat: 'https://github.com/puppetlabs/puppetlabs-concat.git'
+    file_concat: 'https://github.com/electrical/puppet-lib-file_concat.git'
+    systemd: 'https://github.com/camptocamp/puppet-systemd.git'
+    cron: 'https://github.com/voxpupuli/puppet-cron.git'
     cron_core:
       repo: https://github.com/puppetlabs/puppetlabs-cron_core.git
       puppet_version: ">= 6.0.0"

--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "author": "puppetlabs",
   "summary": "Installs PostgreSQL and PuppetDB, sets up the connection to Puppet master.",
   "license": "Apache-2.0",
-  "source": "git://github.com/puppetlabs/puppetlabs-puppetdb.git",
+  "source": "https://github.com/puppetlabs/puppetlabs-puppetdb.git",
   "project_page": "http://github.com/puppetlabs/puppetlabs-puppetdb",
   "issues_url": "https://tickets.puppetlabs.com/browse/PDB",
   "dependencies": [


### PR DESCRIPTION
Per [github](https://github.blog/2021-09-01-improving-git-protocol-security-github/), "unencrypted git:// offers no integrity or authentication, [...] We’ll be disabling support for this protocol."

This switches the protocols to https:// which they indicate is unaffected.