### PR TITLE
Mark as compatible with puppetlabs/postgresql 8.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/postgresql",
-      "version_requirement": ">= 6.5.0 < 8.0.0"
+      "version_requirement": ">= 6.5.0 < 9.0.0"
     },
     {
       "name": "puppetlabs/firewall",


### PR DESCRIPTION
This brings compatibility with newer Debian versions where there is no contrib package.