### PR TITLE
Fix legacy fact usage

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -4,8 +4,8 @@ class puppetdb::globals (
   $database                     = 'postgres',
   ) {
 
-  if !($::osfamily in ['RedHat', 'Suse', 'Archlinux', 'Debian', 'OpenBSD', 'FreeBSD']) {
-    fail("${module_name} does not support your osfamily ${::osfamily}")
+  if !(fact('os.family') in ['RedHat', 'Suse', 'Archlinux', 'Debian', 'OpenBSD', 'FreeBSD']) {
+    fail("${module_name} does not support your osfamily ${fact('os.family')}")
   }
 
 }

--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -1,6 +1,6 @@
 # Manage puppet configuration. See README.md for more details.
 class puppetdb::master::config (
-  $puppetdb_server             = $::fqdn,
+  $puppetdb_server             = fact('networking.fqdn'),
   $puppetdb_port               = defined(Class['puppetdb']) ? {
     true    => $::puppetdb::disable_ssl ? {
       true => 8080,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@ class puppetdb::params inherits puppetdb::globals {
   $manage_dbserver           = true
   $manage_database           = true
 
-  if $::osfamily =~ /RedHat|Debian/ {
+  if fact('os.family') =~ /RedHat|Debian/ {
     $manage_pg_repo            = true
   } else {
     $manage_pg_repo            = false
@@ -41,7 +41,7 @@ class puppetdb::params inherits puppetdb::globals {
   $jdbc_ssl_properties    = ''
   $database_validate      = true
   $database_max_pool_size = undef
-  $puppetdb_server        = $::fqdn
+  $puppetdb_server        = fact('networking.fqdn')
 
   # These settings manage the various auto-deactivation and auto-purge settings
   $node_ttl               = '7d'
@@ -86,7 +86,7 @@ class puppetdb::params inherits puppetdb::globals {
   $masterless           = false
 
   if !($puppetdb_version in ['latest','present','absent']) and versioncmp($puppetdb_version, '3.0.0') < 0 {
-    case $::osfamily {
+    case fact('os.family') {
       'RedHat', 'Suse', 'Archlinux','Debian': {
         $etcdir                 = '/etc/puppetdb'
         $vardir                 = '/var/lib/puppetdb'
@@ -109,13 +109,13 @@ class puppetdb::params inherits puppetdb::globals {
         $puppet_service_name    = 'puppetmaster'
       }
       default: {
-        fail("The fact 'osfamily' is set to ${::osfamily} which is not supported by the puppetdb module.")
+        fail("The fact 'os.family' is set to ${fact('os.family')} which is not supported by the puppetdb module.")
       }
     }
     $terminus_package = 'puppetdb-terminus'
     $test_url         = '/v3/version'
   } else {
-    case $::osfamily {
+    case fact('os.family') {
       'RedHat', 'Suse', 'Archlinux','Debian': {
         $etcdir              = '/etc/puppetlabs/puppetdb'
         $puppet_confdir      = pick($settings::confdir,'/etc/puppetlabs/puppet')
@@ -132,7 +132,7 @@ class puppetdb::params inherits puppetdb::globals {
         $puppet_service_name = undef
       }
       default: {
-        fail("The fact 'osfamily' is set to ${::osfamily} which is not supported by the puppetdb module.")
+        fail("The fact 'os.family' is set to ${fact('os.family')} which is not supported by the puppetdb module.")
       }
     }
     $terminus_package       = 'puppetdb-termini'
@@ -144,7 +144,7 @@ class puppetdb::params inherits puppetdb::globals {
   $confdir = "${etcdir}/conf.d"
   $ssl_dir = "${etcdir}/ssl"
 
-  case $::osfamily {
+  case fact('os.family') {
     'RedHat', 'Suse', 'Archlinux': {
       $puppetdb_user     = 'puppetdb'
       $puppetdb_group    = 'puppetdb'
@@ -166,7 +166,7 @@ class puppetdb::params inherits puppetdb::globals {
       $puppetdb_initconf = undef
     }
     default: {
-      fail("The fact 'osfamily' is set to ${::osfamily} which is not supported by the puppetdb module.")
+      fail("The fact 'os.family' is set to ${fact('os.family')} which is not supported by the puppetdb module.")
     }
   }
 


### PR DESCRIPTION
This allows to test control-repos catalogs with onceover using factsets
that do not include legacy facts.
