### PR TITLE
(maint) Remove dynamic-scoped resource defaults

### DIFF
--- a/manifests/master/puppetdb_conf.pp
+++ b/manifests/master/puppetdb_conf.pp
@@ -22,26 +22,26 @@ class puppetdb::master::puppetdb_conf (
 
   if $legacy_terminus {
     ini_setting { 'puppetdbserver':
-      *       => $ini_setting_defaults,
       setting => 'server',
       value   => $server,
+      *       => $ini_setting_defaults,
     }
     ini_setting { 'puppetdbport':
-      *       => $ini_setting_defaults,
       setting => 'port',
       value   => $port,
+      *       => $ini_setting_defaults,
     }
   } else {
     ini_setting { 'puppetdbserver_urls':
-      *       => $ini_setting_defaults,
       setting => 'server_urls',
       value   => "https://${server}:${port}/",
+      *       => $ini_setting_defaults,
     }
   }
 
   ini_setting { 'soft_write_failure':
-      *       => $ini_setting_defaults,
     setting => 'soft_write_failure',
     value   => $soft_write_failure,
+    *       => $ini_setting_defaults,
   }
 }

--- a/manifests/master/puppetdb_conf.pp
+++ b/manifests/master/puppetdb_conf.pp
@@ -14,7 +14,7 @@ class puppetdb::master::puppetdb_conf (
   },
   ) inherits puppetdb::params {
 
-  Ini_setting {
+  $ini_setting_defaults = {
     ensure  => present,
     section => 'main',
     path    => "${puppet_confdir}/puppetdb.conf",
@@ -22,21 +22,25 @@ class puppetdb::master::puppetdb_conf (
 
   if $legacy_terminus {
     ini_setting { 'puppetdbserver':
+      *       => $ini_setting_defaults,
       setting => 'server',
       value   => $server,
     }
     ini_setting { 'puppetdbport':
+      *       => $ini_setting_defaults,
       setting => 'port',
       value   => $port,
     }
   } else {
     ini_setting { 'puppetdbserver_urls':
+      *       => $ini_setting_defaults,
       setting => 'server_urls',
       value   => "https://${server}:${port}/",
     }
   }
 
   ini_setting { 'soft_write_failure':
+      *       => $ini_setting_defaults,
     setting => 'soft_write_failure',
     value   => $soft_write_failure,
   }

--- a/manifests/master/storeconfigs.pp
+++ b/manifests/master/storeconfigs.pp
@@ -17,18 +17,20 @@ class puppetdb::master::storeconfigs (
     default => absent,
   }
 
-  Ini_setting {
+  $ini_setting_defaults = {
     section => $puppet_conf_section,
     path    => $puppet_conf,
     ensure  => $storeconfigs_ensure,
   }
 
   ini_setting { "puppet.conf/${puppet_conf_section}/storeconfigs":
+      *       => $ini_setting_defaults,
     setting => 'storeconfigs',
     value   => true,
   }
 
   ini_setting { "puppet.conf/${puppet_conf_section}/storeconfigs_backend":
+      *       => $ini_setting_defaults,
     setting => 'storeconfigs_backend',
     value   => 'puppetdb',
   }

--- a/manifests/master/storeconfigs.pp
+++ b/manifests/master/storeconfigs.pp
@@ -24,14 +24,14 @@ class puppetdb::master::storeconfigs (
   }
 
   ini_setting { "puppet.conf/${puppet_conf_section}/storeconfigs":
-      *       => $ini_setting_defaults,
     setting => 'storeconfigs',
     value   => true,
+    *       => $ini_setting_defaults,
   }
 
   ini_setting { "puppet.conf/${puppet_conf_section}/storeconfigs_backend":
-      *       => $ini_setting_defaults,
     setting => 'storeconfigs_backend',
     value   => 'puppetdb',
+    *       => $ini_setting_defaults,
   }
 }

--- a/manifests/server/command_processing.pp
+++ b/manifests/server/command_processing.pp
@@ -10,7 +10,7 @@ class puppetdb::server::command_processing (
   $config_ini = "${confdir}/config.ini"
 
   # Set the defaults
-  Ini_setting {
+  $ini_setting_defaults = {
     path    => $config_ini,
     ensure  => 'present',
     section => 'command-processing',
@@ -19,11 +19,13 @@ class puppetdb::server::command_processing (
 
   if $command_threads {
     ini_setting { 'puppetdb_command_processing_threads':
+      *       => $ini_setting_defaults,
       setting => 'threads',
       value   => $command_threads,
     }
   } else {
     ini_setting { 'puppetdb_command_processing_threads':
+      *       => $ini_setting_defaults,
       ensure  => 'absent',
       setting => 'threads',
     }
@@ -31,11 +33,13 @@ class puppetdb::server::command_processing (
 
   if $concurrent_writes {
     ini_setting { 'puppetdb_command_processing_concurrent_writes':
+      *       => $ini_setting_defaults,
       setting => 'concurrent-writes',
       value   => $concurrent_writes,
     }
   } else {
     ini_setting { 'puppetdb_command_processing_concurrent_writes':
+      *       => $ini_setting_defaults,
       ensure  => 'absent',
       setting => 'concurrent-writes',
     }
@@ -43,11 +47,13 @@ class puppetdb::server::command_processing (
 
   if $store_usage {
     ini_setting { 'puppetdb_command_processing_store_usage':
+      *       => $ini_setting_defaults,
       setting => 'store-usage',
       value   => $store_usage,
     }
   } else {
     ini_setting { 'puppetdb_command_processing_store_usage':
+      *       => $ini_setting_defaults,
       ensure  => 'absent',
       setting => 'store-usage',
     }
@@ -55,11 +61,13 @@ class puppetdb::server::command_processing (
 
   if $temp_usage {
     ini_setting { 'puppetdb_command_processing_temp_usage':
+      *       => $ini_setting_defaults,
       setting => 'temp-usage',
       value   => $temp_usage,
     }
   } else {
     ini_setting { 'puppetdb_command_processing_temp_usage':
+      *       => $ini_setting_defaults,
       ensure  => 'absent',
       setting => 'temp-usage',
     }

--- a/manifests/server/command_processing.pp
+++ b/manifests/server/command_processing.pp
@@ -12,64 +12,67 @@ class puppetdb::server::command_processing (
   # Set the defaults
   $ini_setting_defaults = {
     path    => $config_ini,
-    ensure  => 'present',
     section => 'command-processing',
     require => File[$config_ini],
   }
 
   if $command_threads {
     ini_setting { 'puppetdb_command_processing_threads':
-      *       => $ini_setting_defaults,
+      ensure  => 'present',
       setting => 'threads',
       value   => $command_threads,
+      *       => $ini_setting_defaults,
     }
   } else {
     ini_setting { 'puppetdb_command_processing_threads':
-      *       => $ini_setting_defaults,
       ensure  => 'absent',
       setting => 'threads',
+      *       => $ini_setting_defaults,
     }
   }
 
   if $concurrent_writes {
     ini_setting { 'puppetdb_command_processing_concurrent_writes':
-      *       => $ini_setting_defaults,
+      ensure  => 'present',
       setting => 'concurrent-writes',
       value   => $concurrent_writes,
+      *       => $ini_setting_defaults,
     }
   } else {
     ini_setting { 'puppetdb_command_processing_concurrent_writes':
-      *       => $ini_setting_defaults,
       ensure  => 'absent',
       setting => 'concurrent-writes',
+      *       => $ini_setting_defaults,
     }
   }
 
   if $store_usage {
     ini_setting { 'puppetdb_command_processing_store_usage':
-      *       => $ini_setting_defaults,
+      ensure  => 'present',
       setting => 'store-usage',
       value   => $store_usage,
+      *       => $ini_setting_defaults,
     }
   } else {
     ini_setting { 'puppetdb_command_processing_store_usage':
-      *       => $ini_setting_defaults,
       ensure  => 'absent',
       setting => 'store-usage',
+      *       => $ini_setting_defaults,
     }
   }
 
   if $temp_usage {
     ini_setting { 'puppetdb_command_processing_temp_usage':
-      *       => $ini_setting_defaults,
+      ensure  => 'present',
       setting => 'temp-usage',
       value   => $temp_usage,
+      *       => $ini_setting_defaults,
     }
   } else {
     ini_setting { 'puppetdb_command_processing_temp_usage':
-      *       => $ini_setting_defaults,
       ensure  => 'absent',
       setting => 'temp-usage',
+      *       => $ini_setting_defaults,
     }
   }
 }

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -71,8 +71,6 @@ class puppetdb::server::database (
     require => $ini_setting_require
   }
 
-  $ini_setting_present_defaults = $ini_setting_defaults + { ensure => present }
-
   if $database == 'embedded' {
 
     $classname = 'org.hsqldb.jdbcDriver'
@@ -110,103 +108,85 @@ class puppetdb::server::database (
 
     ##Only setup for postgres
     ini_setting { 'puppetdb_psdatabase_username':
+      ensure  => present,
       setting => 'username',
       value   => $database_username,
-      *       => $ini_setting_present_defaults,
+      *       => $ini_setting_defaults,
     }
 
     if $database_password != undef and $manage_db_password {
       ini_setting { 'puppetdb_psdatabase_password':
+        ensure  => present,
         setting => 'password',
         value   => $database_password,
-        *       => $ini_setting_present_defaults,
+        *       => $ini_setting_defaults,
       }
     }
   }
 
-  ini_setting { 'puppetdb_classname':
-    setting => 'classname',
-    value   => $classname,
-    *       => $ini_setting_present_defaults,
+  ini_setting{
+    default:
+      ensure => present,
+      *      => $ini_setting_defaults,
+    ;
+    'puppetdb_classname':
+      setting => 'classname',
+      value   => $classname,
+    ;
+    'puppetdb_subprotocol':
+      setting => 'subprotocol',
+      value   => $subprotocol,
+    ;
+    'puppetdb_pgs':
+      setting => 'syntax_pgs',
+      value   => true,
+    ;
+    'puppetdb_subname':
+      setting => 'subname',
+      value   => $subname,
+    ;
+    'puppetdb_gc_interval':
+      setting => 'gc-interval',
+      value   => $gc_interval,
+    ;
+    'puppetdb_node_purge_gc_batch_limit':
+      setting => 'node-purge-gc-batch-limit',
+      value   => $node_purge_gc_batch_limit,
+    ;
+    'puppetdb_node_ttl':
+      setting => 'node-ttl',
+      value   => $node_ttl,
+    ;
+    'puppetdb_node_purge_ttl':
+      setting => 'node-purge-ttl',
+      value   => $node_purge_ttl,
+    ;
+    'puppetdb_report_ttl':
+      setting => 'report-ttl',
+      value   => $report_ttl,
+    ;
+    'puppetdb_log_slow_statements':
+      setting => 'log-slow-statements',
+      value   => $log_slow_statements,
+    ;
+    'puppetdb_conn_max_age':
+      setting => 'conn-max-age',
+      value   => $conn_max_age,
+    ;
+    'puppetdb_conn_keep_alive':
+      setting => 'conn-keep-alive',
+      value   => $conn_keep_alive,
+    ;
+    'puppetdb_conn_lifetime':
+      setting => 'conn-lifetime',
+      value   => $conn_lifetime,
+    ;
+    'puppetdb_migrate':
+      setting => 'migrate',
+      value   => $migrate,
+    ;
   }
 
-  ini_setting { 'puppetdb_subprotocol':
-    setting => 'subprotocol',
-    value   => $subprotocol,
-    *       => $ini_setting_present_defaults,
-  }
-
-  ini_setting { 'puppetdb_pgs':
-    setting => 'syntax_pgs',
-    value   => true,
-    *       => $ini_setting_present_defaults,
-  }
-
-  ini_setting { 'puppetdb_subname':
-    setting => 'subname',
-    value   => $subname,
-    *       => $ini_setting_present_defaults,
-  }
-
-  ini_setting { 'puppetdb_gc_interval':
-    setting => 'gc-interval',
-    value   => $gc_interval,
-    *       => $ini_setting_present_defaults,
-  }
-
-  ini_setting { 'puppetdb_node_purge_gc_batch_limit':
-    setting => 'node-purge-gc-batch-limit',
-    value   => $node_purge_gc_batch_limit,
-    *       => $ini_setting_present_defaults,
-  }
-
-  ini_setting { 'puppetdb_node_ttl':
-    setting => 'node-ttl',
-    value   => $node_ttl,
-    *       => $ini_setting_present_defaults,
-  }
-
-  ini_setting { 'puppetdb_node_purge_ttl':
-    setting => 'node-purge-ttl',
-    value   => $node_purge_ttl,
-    *       => $ini_setting_present_defaults,
-  }
-
-  ini_setting { 'puppetdb_report_ttl':
-    setting => 'report-ttl',
-    value   => $report_ttl,
-    *       => $ini_setting_present_defaults,
-  }
-
-  ini_setting { 'puppetdb_log_slow_statements':
-    setting => 'log-slow-statements',
-    value   => $log_slow_statements,
-    *       => $ini_setting_present_defaults,
-  }
-
-  ini_setting { 'puppetdb_conn_max_age':
-    setting => 'conn-max-age',
-    value   => $conn_max_age,
-    *       => $ini_setting_present_defaults,
-  }
-
-  ini_setting { 'puppetdb_conn_keep_alive':
-    setting => 'conn-keep-alive',
-    value   => $conn_keep_alive,
-    *       => $ini_setting_present_defaults,
-  }
-
-  ini_setting { 'puppetdb_conn_lifetime':
-    setting => 'conn-lifetime',
-    value   => $conn_lifetime,
-    *       => $ini_setting_present_defaults,
-  }
-
-  ini_setting { 'puppetdb_migrate':
-    setting => 'migrate',
-    value   => $migrate,
-    *       => $ini_setting_present_defaults,
-  }
 
   if $puppetdb::params::database_max_pool_size_setting_name != undef {
     if $database_max_pool_size == 'absent' {
@@ -217,9 +197,10 @@ class puppetdb::server::database (
       }
     } elsif $database_max_pool_size != undef {
       ini_setting { 'puppetdb_database_max_pool_size':
+        ensure  => present,
         setting => $puppetdb::params::database_max_pool_size_setting_name,
         value   => $database_max_pool_size,
-        *       => $ini_setting_present_defaults,
+        *       => $ini_setting_defaults,
       }
     }
   }
@@ -227,9 +208,10 @@ class puppetdb::server::database (
   if ($facts_blacklist) and length($facts_blacklist) != 0 {
     $joined_facts_blacklist = join($facts_blacklist, ', ')
     ini_setting { 'puppetdb_facts_blacklist':
+      ensure  => present,
       setting => 'facts-blacklist',
       value   => $joined_facts_blacklist,
-      *       => $ini_setting_present_defaults,
+      *       => $ini_setting_defaults,
     }
   } else {
     ini_setting { 'puppetdb_facts_blacklist':

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -67,10 +67,11 @@ class puppetdb::server::database (
   # Set the defaults
   $ini_setting_defaults = {
     path    => $database_ini,
-    ensure  => present,
     section => 'database',
     require => $ini_setting_require
   }
+
+  $ini_setting_present_defaults = $ini_setting_defaults + { ensure => present }
 
   if $database == 'embedded' {
 
@@ -109,116 +110,116 @@ class puppetdb::server::database (
 
     ##Only setup for postgres
     ini_setting { 'puppetdb_psdatabase_username':
-      *       => $ini_setting_defaults,
       setting => 'username',
       value   => $database_username,
+      *       => $ini_setting_present_defaults,
     }
 
     if $database_password != undef and $manage_db_password {
       ini_setting { 'puppetdb_psdatabase_password':
-      *       => $ini_setting_defaults,
         setting => 'password',
         value   => $database_password,
+        *       => $ini_setting_present_defaults,
       }
     }
   }
 
   ini_setting { 'puppetdb_classname':
-      *       => $ini_setting_defaults,
     setting => 'classname',
     value   => $classname,
+    *       => $ini_setting_present_defaults,
   }
 
   ini_setting { 'puppetdb_subprotocol':
-      *       => $ini_setting_defaults,
     setting => 'subprotocol',
     value   => $subprotocol,
+    *       => $ini_setting_present_defaults,
   }
 
   ini_setting { 'puppetdb_pgs':
-      *       => $ini_setting_defaults,
     setting => 'syntax_pgs',
     value   => true,
+    *       => $ini_setting_present_defaults,
   }
 
   ini_setting { 'puppetdb_subname':
-      *       => $ini_setting_defaults,
     setting => 'subname',
     value   => $subname,
+    *       => $ini_setting_present_defaults,
   }
 
   ini_setting { 'puppetdb_gc_interval':
-      *       => $ini_setting_defaults,
     setting => 'gc-interval',
     value   => $gc_interval,
+    *       => $ini_setting_present_defaults,
   }
 
   ini_setting { 'puppetdb_node_purge_gc_batch_limit':
-      *       => $ini_setting_defaults,
     setting => 'node-purge-gc-batch-limit',
     value   => $node_purge_gc_batch_limit,
+    *       => $ini_setting_present_defaults,
   }
 
   ini_setting { 'puppetdb_node_ttl':
-      *       => $ini_setting_defaults,
     setting => 'node-ttl',
     value   => $node_ttl,
+    *       => $ini_setting_present_defaults,
   }
 
   ini_setting { 'puppetdb_node_purge_ttl':
-      *       => $ini_setting_defaults,
     setting => 'node-purge-ttl',
     value   => $node_purge_ttl,
+    *       => $ini_setting_present_defaults,
   }
 
   ini_setting { 'puppetdb_report_ttl':
-      *       => $ini_setting_defaults,
     setting => 'report-ttl',
     value   => $report_ttl,
+    *       => $ini_setting_present_defaults,
   }
 
   ini_setting { 'puppetdb_log_slow_statements':
-      *       => $ini_setting_defaults,
     setting => 'log-slow-statements',
     value   => $log_slow_statements,
+    *       => $ini_setting_present_defaults,
   }
 
   ini_setting { 'puppetdb_conn_max_age':
-      *       => $ini_setting_defaults,
     setting => 'conn-max-age',
     value   => $conn_max_age,
+    *       => $ini_setting_present_defaults,
   }
 
   ini_setting { 'puppetdb_conn_keep_alive':
-      *       => $ini_setting_defaults,
     setting => 'conn-keep-alive',
     value   => $conn_keep_alive,
+    *       => $ini_setting_present_defaults,
   }
 
   ini_setting { 'puppetdb_conn_lifetime':
-      *       => $ini_setting_defaults,
     setting => 'conn-lifetime',
     value   => $conn_lifetime,
+    *       => $ini_setting_present_defaults,
   }
 
   ini_setting { 'puppetdb_migrate':
-      *       => $ini_setting_defaults,
     setting => 'migrate',
     value   => $migrate,
+    *       => $ini_setting_present_defaults,
   }
 
   if $puppetdb::params::database_max_pool_size_setting_name != undef {
     if $database_max_pool_size == 'absent' {
       ini_setting { 'puppetdb_database_max_pool_size':
-      *       => $ini_setting_defaults,
         ensure  => absent,
         setting => $puppetdb::params::database_max_pool_size_setting_name,
+        *       => $ini_setting_defaults,
       }
     } elsif $database_max_pool_size != undef {
       ini_setting { 'puppetdb_database_max_pool_size':
-      *       => $ini_setting_defaults,
         setting => $puppetdb::params::database_max_pool_size_setting_name,
         value   => $database_max_pool_size,
+        *       => $ini_setting_present_defaults,
       }
     }
   }
@@ -226,15 +227,15 @@ class puppetdb::server::database (
   if ($facts_blacklist) and length($facts_blacklist) != 0 {
     $joined_facts_blacklist = join($facts_blacklist, ', ')
     ini_setting { 'puppetdb_facts_blacklist':
-      *       => $ini_setting_defaults,
       setting => 'facts-blacklist',
       value   => $joined_facts_blacklist,
+      *       => $ini_setting_present_defaults,
     }
   } else {
     ini_setting { 'puppetdb_facts_blacklist':
-      *       => $ini_setting_defaults,
       ensure  => absent,
       setting => 'facts-blacklist',
+      *       => $ini_setting_defaults,
     }
   }
 }

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -65,7 +65,7 @@ class puppetdb::server::database (
     default => [$file_require, Class['puppetdb::server::validate_db']],
   }
   # Set the defaults
-  Ini_setting {
+  $ini_setting_defaults = {
     path    => $database_ini,
     ensure  => present,
     section => 'database',
@@ -109,12 +109,14 @@ class puppetdb::server::database (
 
     ##Only setup for postgres
     ini_setting { 'puppetdb_psdatabase_username':
+      *       => $ini_setting_defaults,
       setting => 'username',
       value   => $database_username,
     }
 
     if $database_password != undef and $manage_db_password {
       ini_setting { 'puppetdb_psdatabase_password':
+      *       => $ini_setting_defaults,
         setting => 'password',
         value   => $database_password,
       }
@@ -122,71 +124,85 @@ class puppetdb::server::database (
   }
 
   ini_setting { 'puppetdb_classname':
+      *       => $ini_setting_defaults,
     setting => 'classname',
     value   => $classname,
   }
 
   ini_setting { 'puppetdb_subprotocol':
+      *       => $ini_setting_defaults,
     setting => 'subprotocol',
     value   => $subprotocol,
   }
 
   ini_setting { 'puppetdb_pgs':
+      *       => $ini_setting_defaults,
     setting => 'syntax_pgs',
     value   => true,
   }
 
   ini_setting { 'puppetdb_subname':
+      *       => $ini_setting_defaults,
     setting => 'subname',
     value   => $subname,
   }
 
   ini_setting { 'puppetdb_gc_interval':
+      *       => $ini_setting_defaults,
     setting => 'gc-interval',
     value   => $gc_interval,
   }
 
   ini_setting { 'puppetdb_node_purge_gc_batch_limit':
+      *       => $ini_setting_defaults,
     setting => 'node-purge-gc-batch-limit',
     value   => $node_purge_gc_batch_limit,
   }
 
   ini_setting { 'puppetdb_node_ttl':
+      *       => $ini_setting_defaults,
     setting => 'node-ttl',
     value   => $node_ttl,
   }
 
   ini_setting { 'puppetdb_node_purge_ttl':
+      *       => $ini_setting_defaults,
     setting => 'node-purge-ttl',
     value   => $node_purge_ttl,
   }
 
   ini_setting { 'puppetdb_report_ttl':
+      *       => $ini_setting_defaults,
     setting => 'report-ttl',
     value   => $report_ttl,
   }
 
   ini_setting { 'puppetdb_log_slow_statements':
+      *       => $ini_setting_defaults,
     setting => 'log-slow-statements',
     value   => $log_slow_statements,
   }
 
   ini_setting { 'puppetdb_conn_max_age':
+      *       => $ini_setting_defaults,
     setting => 'conn-max-age',
     value   => $conn_max_age,
   }
 
   ini_setting { 'puppetdb_conn_keep_alive':
+      *       => $ini_setting_defaults,
     setting => 'conn-keep-alive',
     value   => $conn_keep_alive,
   }
 
   ini_setting { 'puppetdb_conn_lifetime':
+      *       => $ini_setting_defaults,
     setting => 'conn-lifetime',
     value   => $conn_lifetime,
   }
 
   ini_setting { 'puppetdb_migrate':
+      *       => $ini_setting_defaults,
     setting => 'migrate',
     value   => $migrate,
   }
@@ -194,11 +210,13 @@ class puppetdb::server::database (
   if $puppetdb::params::database_max_pool_size_setting_name != undef {
     if $database_max_pool_size == 'absent' {
       ini_setting { 'puppetdb_database_max_pool_size':
+      *       => $ini_setting_defaults,
         ensure  => absent,
         setting => $puppetdb::params::database_max_pool_size_setting_name,
       }
     } elsif $database_max_pool_size != undef {
       ini_setting { 'puppetdb_database_max_pool_size':
+      *       => $ini_setting_defaults,
         setting => $puppetdb::params::database_max_pool_size_setting_name,
         value   => $database_max_pool_size,
       }
@@ -208,11 +226,13 @@ class puppetdb::server::database (
   if ($facts_blacklist) and length($facts_blacklist) != 0 {
     $joined_facts_blacklist = join($facts_blacklist, ', ')
     ini_setting { 'puppetdb_facts_blacklist':
+      *       => $ini_setting_defaults,
       setting => 'facts-blacklist',
       value   => $joined_facts_blacklist,
     }
   } else {
     ini_setting { 'puppetdb_facts_blacklist':
+      *       => $ini_setting_defaults,
       ensure  => absent,
       setting => 'facts-blacklist',
     }

--- a/manifests/server/global.pp
+++ b/manifests/server/global.pp
@@ -16,7 +16,7 @@ class puppetdb::server::global (
   }
 
   # Set the defaults
-  Ini_setting {
+  $ini_setting_defaults = {
     path    => $config_ini,
     ensure  => 'present',
     section => 'global',
@@ -25,6 +25,7 @@ class puppetdb::server::global (
 
   if $vardir {
     ini_setting { 'puppetdb_global_vardir':
+      *       => $ini_setting_defaults,
       setting => 'vardir',
       value   => $vardir,
     }

--- a/manifests/server/global.pp
+++ b/manifests/server/global.pp
@@ -18,13 +18,13 @@ class puppetdb::server::global (
   # Set the defaults
   $ini_setting_defaults = {
     path    => $config_ini,
-    ensure  => 'present',
     section => 'global',
     require => File[$config_ini],
   }
 
   if $vardir {
     ini_setting { 'puppetdb_global_vardir':
+      ensure  => present,
       setting => 'vardir',
       value   => $vardir,
       *       => $ini_setting_defaults,

--- a/manifests/server/global.pp
+++ b/manifests/server/global.pp
@@ -25,9 +25,9 @@ class puppetdb::server::global (
 
   if $vardir {
     ini_setting { 'puppetdb_global_vardir':
-      *       => $ini_setting_defaults,
       setting => 'vardir',
       value   => $vardir,
+      *       => $ini_setting_defaults,
     }
   }
 }

--- a/manifests/server/jetty.pp
+++ b/manifests/server/jetty.pp
@@ -28,7 +28,7 @@ class puppetdb::server::jetty (
   }
 
   # Set the defaults
-  Ini_setting {
+  $ini_setting_defaults = {
     path    => $jetty_ini,
     ensure  => present,
     section => 'jetty',
@@ -41,12 +41,14 @@ class puppetdb::server::jetty (
   }
 
   ini_setting { 'puppetdb_host':
+      *       => $ini_setting_defaults,
     ensure  => $cleartext_setting_ensure,
     setting => 'host',
     value   => $listen_address,
   }
 
   ini_setting { 'puppetdb_port':
+      *       => $ini_setting_defaults,
     ensure  => $cleartext_setting_ensure,
     setting => 'port',
     value   => $listen_port,
@@ -58,12 +60,14 @@ class puppetdb::server::jetty (
   }
 
   ini_setting { 'puppetdb_sslhost':
+      *       => $ini_setting_defaults,
     ensure  => $ssl_setting_ensure,
     setting => 'ssl-host',
     value   => $ssl_listen_address,
   }
 
   ini_setting { 'puppetdb_sslport':
+      *       => $ini_setting_defaults,
     ensure  => $ssl_setting_ensure,
     setting => 'ssl-port',
     value   => $ssl_listen_port,
@@ -72,6 +76,7 @@ class puppetdb::server::jetty (
   if $ssl_protocols {
 
     ini_setting { 'puppetdb_sslprotocols':
+      *       => $ini_setting_defaults,
       ensure  => $ssl_setting_ensure,
       setting => 'ssl-protocols',
       value   => $ssl_protocols,
@@ -81,6 +86,7 @@ class puppetdb::server::jetty (
   if $cipher_suites {
 
     ini_setting { 'puppetdb_cipher-suites':
+      *       => $ini_setting_defaults,
       ensure  => $ssl_setting_ensure,
       setting => 'cipher-suites',
       value   => $cipher_suites,
@@ -90,16 +96,19 @@ class puppetdb::server::jetty (
   if $ssl_set_cert_paths {
     # assume paths have been validated in calling class
     ini_setting { 'puppetdb_ssl_key':
+      *       => $ini_setting_defaults,
       ensure  => present,
       setting => 'ssl-key',
       value   => $ssl_key_path,
     }
     ini_setting { 'puppetdb_ssl_cert':
+      *       => $ini_setting_defaults,
       ensure  => present,
       setting => 'ssl-cert',
       value   => $ssl_cert_path,
     }
     ini_setting { 'puppetdb_ssl_ca_cert':
+      *       => $ini_setting_defaults,
       ensure  => present,
       setting => 'ssl-ca-cert',
       value   => $ssl_ca_cert_path,
@@ -108,11 +117,13 @@ class puppetdb::server::jetty (
 
   if ($max_threads) {
     ini_setting { 'puppetdb_max_threads':
+      *       => $ini_setting_defaults,
       setting => 'max-threads',
       value   => $max_threads,
     }
   } else {
     ini_setting { 'puppetdb_max_threads':
+      *       => $ini_setting_defaults,
       ensure  => absent,
       setting => 'max-threads',
     }

--- a/manifests/server/jetty.pp
+++ b/manifests/server/jetty.pp
@@ -39,37 +39,35 @@ class puppetdb::server::jetty (
     default => 'present',
   }
 
-  ini_setting { 'puppetdb_host':
-    ensure  => $cleartext_setting_ensure,
-    setting => 'host',
-    value   => $listen_address,
-    *       => $ini_setting_defaults,
-  }
-
-  ini_setting { 'puppetdb_port':
-    ensure  => $cleartext_setting_ensure,
-    setting => 'port',
-    value   => $listen_port,
-    *       => $ini_setting_defaults,
-  }
-
   $ssl_setting_ensure = $disable_ssl ? {
     true    => 'absent',
     default => 'present',
   }
 
-  ini_setting { 'puppetdb_sslhost':
-    ensure  => $ssl_setting_ensure,
-    setting => 'ssl-host',
-    value   => $ssl_listen_address,
-    *       => $ini_setting_defaults,
-  }
-
-  ini_setting { 'puppetdb_sslport':
-    ensure  => $ssl_setting_ensure,
-    setting => 'ssl-port',
-    value   => $ssl_listen_port,
-    *       => $ini_setting_defaults,
+  ini_setting {
+    default:
+      *      => $ini_setting_defaults,
+    ;
+    'puppetdb_host':
+      ensure  => $cleartext_setting_ensure,
+      setting => 'host',
+      value   => $listen_address,
+    ;
+    'puppetdb_port':
+      ensure  => $cleartext_setting_ensure,
+      setting => 'port',
+      value   => $listen_port,
+    ;
+    'puppetdb_sslhost':
+      ensure  => $ssl_setting_ensure,
+      setting => 'ssl-host',
+      value   => $ssl_listen_address,
+    ;
+    'puppetdb_sslport':
+      ensure  => $ssl_setting_ensure,
+      setting => 'ssl-port',
+      value   => $ssl_listen_port,
+    ;
   }
 
   if $ssl_protocols {
@@ -94,23 +92,24 @@ class puppetdb::server::jetty (
 
   if $ssl_set_cert_paths {
     # assume paths have been validated in calling class
-    ini_setting { 'puppetdb_ssl_key':
-      ensure  => present,
-      setting => 'ssl-key',
-      value   => $ssl_key_path,
-      *       => $ini_setting_defaults,
-    }
-    ini_setting { 'puppetdb_ssl_cert':
-      ensure  => present,
-      setting => 'ssl-cert',
-      value   => $ssl_cert_path,
-      *       => $ini_setting_defaults,
-    }
-    ini_setting { 'puppetdb_ssl_ca_cert':
-      ensure  => present,
-      setting => 'ssl-ca-cert',
-      value   => $ssl_ca_cert_path,
-      *       => $ini_setting_defaults,
+    #
+    ini_setting {
+      default:
+        ensure => present,
+        *      => $ini_setting_defaults,
+      ;
+      'puppetdb_ssl_key':
+        setting => 'ssl-key',
+        value   => $ssl_key_path,
+      ;
+      'puppetdb_ssl_cert':
+        setting => 'ssl-cert',
+        value   => $ssl_cert_path,
+      ;
+      'puppetdb_ssl_ca_cert':
+        setting => 'ssl-ca-cert',
+        value   => $ssl_ca_cert_path,
+      ;
     }
   }
 

--- a/manifests/server/jetty.pp
+++ b/manifests/server/jetty.pp
@@ -30,7 +30,6 @@ class puppetdb::server::jetty (
   # Set the defaults
   $ini_setting_defaults = {
     path    => $jetty_ini,
-    ensure  => present,
     section => 'jetty',
     require => File[$jetty_ini],
   }
@@ -41,17 +40,17 @@ class puppetdb::server::jetty (
   }
 
   ini_setting { 'puppetdb_host':
-      *       => $ini_setting_defaults,
     ensure  => $cleartext_setting_ensure,
     setting => 'host',
     value   => $listen_address,
+    *       => $ini_setting_defaults,
   }
 
   ini_setting { 'puppetdb_port':
-      *       => $ini_setting_defaults,
     ensure  => $cleartext_setting_ensure,
     setting => 'port',
     value   => $listen_port,
+    *       => $ini_setting_defaults,
   }
 
   $ssl_setting_ensure = $disable_ssl ? {
@@ -60,72 +59,73 @@ class puppetdb::server::jetty (
   }
 
   ini_setting { 'puppetdb_sslhost':
-      *       => $ini_setting_defaults,
     ensure  => $ssl_setting_ensure,
     setting => 'ssl-host',
     value   => $ssl_listen_address,
+    *       => $ini_setting_defaults,
   }
 
   ini_setting { 'puppetdb_sslport':
-      *       => $ini_setting_defaults,
     ensure  => $ssl_setting_ensure,
     setting => 'ssl-port',
     value   => $ssl_listen_port,
+    *       => $ini_setting_defaults,
   }
 
   if $ssl_protocols {
 
     ini_setting { 'puppetdb_sslprotocols':
-      *       => $ini_setting_defaults,
       ensure  => $ssl_setting_ensure,
       setting => 'ssl-protocols',
       value   => $ssl_protocols,
+      *       => $ini_setting_defaults,
     }
   }
 
   if $cipher_suites {
 
     ini_setting { 'puppetdb_cipher-suites':
-      *       => $ini_setting_defaults,
       ensure  => $ssl_setting_ensure,
       setting => 'cipher-suites',
       value   => $cipher_suites,
+      *       => $ini_setting_defaults,
     }
   }
 
   if $ssl_set_cert_paths {
     # assume paths have been validated in calling class
     ini_setting { 'puppetdb_ssl_key':
-      *       => $ini_setting_defaults,
       ensure  => present,
       setting => 'ssl-key',
       value   => $ssl_key_path,
+      *       => $ini_setting_defaults,
     }
     ini_setting { 'puppetdb_ssl_cert':
-      *       => $ini_setting_defaults,
       ensure  => present,
       setting => 'ssl-cert',
       value   => $ssl_cert_path,
+      *       => $ini_setting_defaults,
     }
     ini_setting { 'puppetdb_ssl_ca_cert':
-      *       => $ini_setting_defaults,
       ensure  => present,
       setting => 'ssl-ca-cert',
       value   => $ssl_ca_cert_path,
+      *       => $ini_setting_defaults,
     }
   }
 
   if ($max_threads) {
     ini_setting { 'puppetdb_max_threads':
-      *       => $ini_setting_defaults,
+      ensure  => present,
       setting => 'max-threads',
       value   => $max_threads,
+      *       => $ini_setting_defaults,
     }
   } else {
     ini_setting { 'puppetdb_max_threads':
-      *       => $ini_setting_defaults,
       ensure  => absent,
       setting => 'max-threads',
+      *       => $ini_setting_defaults,
     }
   }
 }

--- a/manifests/server/puppetdb.pp
+++ b/manifests/server/puppetdb.pp
@@ -20,7 +20,6 @@ class puppetdb::server::puppetdb (
   # Set the defaults
   $ini_setting_defaults = {
     path    => $puppetdb_ini,
-    ensure  => present,
     section => 'puppetdb',
     require => File[$puppetdb_ini],
   }
@@ -32,11 +31,11 @@ class puppetdb::server::puppetdb (
 
   # accept connections only from puppet master
   ini_setting {'puppetdb-connections-from-master-only':
-      *       => $ini_setting_defaults,
     ensure  => $certificate_whitelist_setting_ensure,
     section => 'puppetdb',
     setting => 'certificate-whitelist',
     value   => $certificate_whitelist_file,
+    *       => $ini_setting_defaults,
   }
 
   file { $certificate_whitelist_file:
@@ -49,15 +48,16 @@ class puppetdb::server::puppetdb (
 
   if $disable_update_checking {
     ini_setting { 'puppetdb_disable_update_checking':
-      *       => $ini_setting_defaults,
+      ensure  => present,
       setting => 'disable-update-checking',
       value   => $disable_update_checking,
+      *       => $ini_setting_defaults,
     }
   } else {
     ini_setting { 'puppetdb_disable_update_checking':
-      *       => $ini_setting_defaults,
       ensure  => 'absent',
       setting => 'disable-update-checking',
+      *       => $ini_setting_defaults,
     }
   }
 }

--- a/manifests/server/puppetdb.pp
+++ b/manifests/server/puppetdb.pp
@@ -18,7 +18,7 @@ class puppetdb::server::puppetdb (
   }
 
   # Set the defaults
-  Ini_setting {
+  $ini_setting_defaults = {
     path    => $puppetdb_ini,
     ensure  => present,
     section => 'puppetdb',
@@ -32,6 +32,7 @@ class puppetdb::server::puppetdb (
 
   # accept connections only from puppet master
   ini_setting {'puppetdb-connections-from-master-only':
+      *       => $ini_setting_defaults,
     ensure  => $certificate_whitelist_setting_ensure,
     section => 'puppetdb',
     setting => 'certificate-whitelist',
@@ -48,11 +49,13 @@ class puppetdb::server::puppetdb (
 
   if $disable_update_checking {
     ini_setting { 'puppetdb_disable_update_checking':
+      *       => $ini_setting_defaults,
       setting => 'disable-update-checking',
       value   => $disable_update_checking,
     }
   } else {
     ini_setting { 'puppetdb_disable_update_checking':
+      *       => $ini_setting_defaults,
       ensure  => 'absent',
       setting => 'disable-update-checking',
     }

--- a/manifests/server/puppetdb.pp
+++ b/manifests/server/puppetdb.pp
@@ -25,8 +25,8 @@ class puppetdb::server::puppetdb (
   }
 
   $certificate_whitelist_setting_ensure = empty($certificate_whitelist) ? {
-    true    => 'absent',
-    default => 'present',
+    true    => absent,
+    default => present,
   }
 
   # accept connections only from puppet master
@@ -55,7 +55,7 @@ class puppetdb::server::puppetdb (
     }
   } else {
     ini_setting { 'puppetdb_disable_update_checking':
-      ensure  => 'absent',
+      ensure  => absent,
       setting => 'disable-update-checking',
       *       => $ini_setting_defaults,
     }

--- a/manifests/server/read_database.pp
+++ b/manifests/server/read_database.pp
@@ -58,7 +58,7 @@ class puppetdb::server::read_database (
       default => [$file_require, Class['puppetdb::server::validate_read_db']],
     }
     # Set the defaults
-    Ini_setting {
+    $ini_setting_defaults = {
       path    => $read_database_ini,
       ensure  => present,
       section => 'read-database',
@@ -95,12 +95,14 @@ class puppetdb::server::read_database (
       }
 
       ini_setting { 'puppetdb_read_database_username':
+      *       => $ini_setting_defaults,
         setting => 'username',
         value   => $read_database_username,
       }
 
       if $read_database_password != undef and $manage_db_password {
         ini_setting { 'puppetdb_read_database_password':
+      *       => $ini_setting_defaults,
           setting => 'password',
           value   => $read_database_password,
         }
@@ -108,41 +110,49 @@ class puppetdb::server::read_database (
     }
 
     ini_setting { 'puppetdb_read_classname':
+      *       => $ini_setting_defaults,
       setting => 'classname',
       value   => $classname,
     }
 
     ini_setting { 'puppetdb_read_subprotocol':
+      *       => $ini_setting_defaults,
       setting => 'subprotocol',
       value   => $subprotocol,
     }
 
     ini_setting { 'puppetdb_read_pgs':
+      *       => $ini_setting_defaults,
       setting => 'syntax_pgs',
       value   => true,
     }
 
     ini_setting { 'puppetdb_read_subname':
+      *       => $ini_setting_defaults,
       setting => 'subname',
       value   => $subname,
     }
 
     ini_setting { 'puppetdb_read_log_slow_statements':
+      *       => $ini_setting_defaults,
       setting => 'log-slow-statements',
       value   => $log_slow_statements,
     }
 
     ini_setting { 'puppetdb_read_conn_max_age':
+      *       => $ini_setting_defaults,
       setting => 'conn-max-age',
       value   => $conn_max_age,
     }
 
     ini_setting { 'puppetdb_read_conn_keep_alive':
+      *       => $ini_setting_defaults,
       setting => 'conn-keep-alive',
       value   => $conn_keep_alive,
     }
 
     ini_setting { 'puppetdb_read_conn_lifetime':
+      *       => $ini_setting_defaults,
       setting => 'conn-lifetime',
       value   => $conn_lifetime,
     }
@@ -150,11 +160,13 @@ class puppetdb::server::read_database (
     if $puppetdb::params::database_max_pool_size_setting_name != undef {
       if $database_max_pool_size == 'absent' {
         ini_setting { 'puppetdb_read_database_max_pool_size':
+      *       => $ini_setting_defaults,
           ensure  => absent,
           setting => $puppetdb::params::database_max_pool_size_setting_name,
         }
       } elsif $database_max_pool_size != undef {
         ini_setting { 'puppetdb_read_database_max_pool_size':
+      *       => $ini_setting_defaults,
           setting => $puppetdb::params::database_max_pool_size_setting_name,
           value   => $database_max_pool_size,
         }

--- a/manifests/server/read_database.pp
+++ b/manifests/server/read_database.pp
@@ -60,10 +60,11 @@ class puppetdb::server::read_database (
     # Set the defaults
     $ini_setting_defaults = {
       path    => $read_database_ini,
-      ensure  => present,
       section => 'read-database',
       require => $ini_setting_require,
     }
+
+    $ini_setting_present_defaults = $ini_setting_defaults + { ensure => present }
 
     if $read_database == 'postgres' {
       $classname = 'org.postgresql.Driver'
@@ -95,80 +96,80 @@ class puppetdb::server::read_database (
       }
 
       ini_setting { 'puppetdb_read_database_username':
-      *       => $ini_setting_defaults,
         setting => 'username',
         value   => $read_database_username,
+        *       => $ini_setting_present_defaults,
       }
 
       if $read_database_password != undef and $manage_db_password {
         ini_setting { 'puppetdb_read_database_password':
-      *       => $ini_setting_defaults,
           setting => 'password',
           value   => $read_database_password,
+          *       => $ini_setting_present_defaults,
         }
       }
     }
 
     ini_setting { 'puppetdb_read_classname':
-      *       => $ini_setting_defaults,
       setting => 'classname',
       value   => $classname,
+      *       => $ini_setting_present_defaults,
     }
 
     ini_setting { 'puppetdb_read_subprotocol':
-      *       => $ini_setting_defaults,
       setting => 'subprotocol',
       value   => $subprotocol,
+      *       => $ini_setting_present_defaults,
     }
 
     ini_setting { 'puppetdb_read_pgs':
-      *       => $ini_setting_defaults,
       setting => 'syntax_pgs',
       value   => true,
+      *       => $ini_setting_present_defaults,
     }
 
     ini_setting { 'puppetdb_read_subname':
-      *       => $ini_setting_defaults,
       setting => 'subname',
       value   => $subname,
+      *       => $ini_setting_present_defaults,
     }
 
     ini_setting { 'puppetdb_read_log_slow_statements':
-      *       => $ini_setting_defaults,
       setting => 'log-slow-statements',
       value   => $log_slow_statements,
+      *       => $ini_setting_present_defaults,
     }
 
     ini_setting { 'puppetdb_read_conn_max_age':
-      *       => $ini_setting_defaults,
       setting => 'conn-max-age',
       value   => $conn_max_age,
+      *       => $ini_setting_present_defaults,
     }
 
     ini_setting { 'puppetdb_read_conn_keep_alive':
-      *       => $ini_setting_defaults,
       setting => 'conn-keep-alive',
       value   => $conn_keep_alive,
+      *       => $ini_setting_present_defaults,
     }
 
     ini_setting { 'puppetdb_read_conn_lifetime':
-      *       => $ini_setting_defaults,
       setting => 'conn-lifetime',
       value   => $conn_lifetime,
+      *       => $ini_setting_present_defaults,
     }
 
     if $puppetdb::params::database_max_pool_size_setting_name != undef {
       if $database_max_pool_size == 'absent' {
         ini_setting { 'puppetdb_read_database_max_pool_size':
-      *       => $ini_setting_defaults,
           ensure  => absent,
           setting => $puppetdb::params::database_max_pool_size_setting_name,
+          *       => $ini_setting_defaults,
         }
       } elsif $database_max_pool_size != undef {
         ini_setting { 'puppetdb_read_database_max_pool_size':
-      *       => $ini_setting_defaults,
           setting => $puppetdb::params::database_max_pool_size_setting_name,
           value   => $database_max_pool_size,
+          *       => $ini_setting_present_defaults,
         }
       }
     } else {

--- a/manifests/server/read_database.pp
+++ b/manifests/server/read_database.pp
@@ -64,8 +64,6 @@ class puppetdb::server::read_database (
       require => $ini_setting_require,
     }
 
-    $ini_setting_present_defaults = $ini_setting_defaults + { ensure => present }
-
     if $read_database == 'postgres' {
       $classname = 'org.postgresql.Driver'
       $subprotocol = 'postgresql'
@@ -96,67 +94,61 @@ class puppetdb::server::read_database (
       }
 
       ini_setting { 'puppetdb_read_database_username':
+        ensure  => present,
         setting => 'username',
         value   => $read_database_username,
-        *       => $ini_setting_present_defaults,
+        *       => $ini_setting_defaults,
       }
 
       if $read_database_password != undef and $manage_db_password {
         ini_setting { 'puppetdb_read_database_password':
+          ensure  => present,
           setting => 'password',
           value   => $read_database_password,
-          *       => $ini_setting_present_defaults,
+          *       => $ini_setting_defaults,
         }
       }
     }
 
-    ini_setting { 'puppetdb_read_classname':
-      setting => 'classname',
-      value   => $classname,
-      *       => $ini_setting_present_defaults,
+    ini_setting {
+      default:
+        ensure => present,
+        *      => $ini_setting_defaults,
+      ;
+      'puppetdb_read_classname':
+        setting => 'classname',
+        value   => $classname,
+      ;
+      'puppetdb_read_subprotocol':
+        setting => 'subprotocol',
+        value   => $subprotocol,
+      ;
+      'puppetdb_read_pgs':
+        setting => 'syntax_pgs',
+        value   => true,
+      ;
+      'puppetdb_read_subname':
+        setting => 'subname',
+        value   => $subname,
+      ;
+      'puppetdb_read_log_slow_statements':
+        setting => 'log-slow-statements',
+        value   => $log_slow_statements,
+      ;
+      'puppetdb_read_conn_max_age':
+        setting => 'conn-max-age',
+        value   => $conn_max_age,
+      ;
+      'puppetdb_read_conn_keep_alive':
+        setting => 'conn-keep-alive',
+        value   => $conn_keep_alive,
+      ;
+      'puppetdb_read_conn_lifetime':
+        setting => 'conn-lifetime',
+        value   => $conn_lifetime,
+      ;
     }
 
-    ini_setting { 'puppetdb_read_subprotocol':
-      setting => 'subprotocol',
-      value   => $subprotocol,
-      *       => $ini_setting_present_defaults,
-    }
-
-    ini_setting { 'puppetdb_read_pgs':
-      setting => 'syntax_pgs',
-      value   => true,
-      *       => $ini_setting_present_defaults,
-    }
-
-    ini_setting { 'puppetdb_read_subname':
-      setting => 'subname',
-      value   => $subname,
-      *       => $ini_setting_present_defaults,
-    }
-
-    ini_setting { 'puppetdb_read_log_slow_statements':
-      setting => 'log-slow-statements',
-      value   => $log_slow_statements,
-      *       => $ini_setting_present_defaults,
-    }
-
-    ini_setting { 'puppetdb_read_conn_max_age':
-      setting => 'conn-max-age',
-      value   => $conn_max_age,
-      *       => $ini_setting_present_defaults,
-    }
-
-    ini_setting { 'puppetdb_read_conn_keep_alive':
-      setting => 'conn-keep-alive',
-      value   => $conn_keep_alive,
-      *       => $ini_setting_present_defaults,
-    }
-
-    ini_setting { 'puppetdb_read_conn_lifetime':
-      setting => 'conn-lifetime',
-      value   => $conn_lifetime,
-      *       => $ini_setting_present_defaults,
-    }
 
     if $puppetdb::params::database_max_pool_size_setting_name != undef {
       if $database_max_pool_size == 'absent' {
@@ -167,9 +159,10 @@ class puppetdb::server::read_database (
         }
       } elsif $database_max_pool_size != undef {
         ini_setting { 'puppetdb_read_database_max_pool_size':
+          ensure  => present,
           setting => $puppetdb::params::database_max_pool_size_setting_name,
           value   => $database_max_pool_size,
-          *       => $ini_setting_present_defaults,
+          *       => $ini_setting_defaults,
         }
       }
     } else {


### PR DESCRIPTION
Prior to this patch, many classes in the puppetdb module overrode
the `Ini_setting` type with their own (different)  parameters & values,
resulting in a Russian roulette of dynamically-scoped default parameters
wherever `ini_setting` is used.

This patch converts all dynamically-scoped parameter "defaults" for the
Ini_settings type to use Hash-bashed attributes and local resource
defaults instead.
