### PR TITLE
Set owner of server config.ini to root

### DIFF
--- a/manifests/server/global.pp
+++ b/manifests/server/global.pp
@@ -2,7 +2,6 @@
 class puppetdb::server::global (
   $vardir         = $puppetdb::params::vardir,
   $confdir        = $puppetdb::params::confdir,
-  $puppetdb_user  = $puppetdb::params::puppetdb_user,
   $puppetdb_group = $puppetdb::params::puppetdb_group,
 ) inherits puppetdb::params {
 
@@ -10,9 +9,9 @@ class puppetdb::server::global (
 
   file { $config_ini:
     ensure => file,
-    owner  => $puppetdb_user,
+    owner  => 'root',
     group  => $puppetdb_group,
-    mode   => '0600',
+    mode   => '0640',
   }
 
   # Set the defaults


### PR DESCRIPTION
The puppetdb user doesn't need to write to the config (it's managed by Puppet after all) so setting the owner to root and using the group to only read is safer.

It is also closer to packaging, which ensures the owner is root after a package update. Ideally packaging would use the same group and mode as well so there isn't an event after a package update, but this change at least trims it down from 3 changes to 2.