### PR TITLE
set encoding when creating the DB

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -149,6 +149,8 @@ class puppetdb::database::postgresql (
     postgresql::server::db { $database_name:
       user     => $database_username,
       password => $database_password,
+      encoding => 'UTF8',
+      locale   => 'en_US.UTF-8',
       grant    => 'all',
       port     => $port,
     }

--- a/spec/unit/classes/database/postgresql_spec.rb
+++ b/spec/unit/classes/database/postgresql_spec.rb
@@ -62,6 +62,8 @@ describe 'puppetdb::database::postgresql', type: :class do
             password: params[:database_password],
             grant:    'all',
             port:     params[:database_port].to_i,
+            encoding: 'UTF8',
+            locale:   'en_US.UTF-8',
           )
       }
 


### PR DESCRIPTION
According to the [docs](https://puppet.com/docs/puppetdb/7/configure_postgres.html) you should specify the encoding when creating the database. The database encoding will be set depending on your locale (I got LATIN1) unless specified.

I am getting some errors is the PuppetDB logs: 
```
ERROR: unsupported Unicode escape sequence Detail: Unicode escape values cannot be used for code point values above 007F when the server encoding is not UTF8.
```
and filling up few gig of additional log at `/opt/puppetlabs/server/data/puppetdb/stockpile/discard`



