### PR TITLE
Fix "has no parameter named 'puppetdb_user'"

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -149,7 +149,6 @@ class puppetdb::server (
   class { 'puppetdb::server::global':
     vardir         => $vardir,
     confdir        => $confdir,
-    puppetdb_user  => $puppetdb_user,
     puppetdb_group => $puppetdb_group,
     notify         => Service[$puppetdb_service],
   }


### PR DESCRIPTION
Fixes 010bf136c78ff84c54903322505aaca6af3d13f8