### PR TITLE
Prefer `clientcert=verify-full` to the deprecated `clientcert=1` in hba rules

### DIFF
--- a/manifests/database/postgresql_ssl_rules.pp
+++ b/manifests/database/postgresql_ssl_rules.pp
@@ -13,7 +13,7 @@ define puppetdb::database::postgresql_ssl_rules (
     address     => '0.0.0.0/0',
     auth_method => 'cert',
     order       => 0,
-    auth_option => "map=${identity_map_key} clientcert=1"
+    auth_option => "map=${identity_map_key} clientcert=verify-full"
   }
 
   postgresql::server::pg_hba_rule { "Allow certificate mapped connections to ${database_name} as ${database_username} (ipv6)":
@@ -23,7 +23,7 @@ define puppetdb::database::postgresql_ssl_rules (
     address     => '::0/0',
     auth_method => 'cert',
     order       => 0,
-    auth_option => "map=${identity_map_key} clientcert=1"
+    auth_option => "map=${identity_map_key} clientcert=verify-full"
   }
 
   postgresql::server::pg_ident_rule { "Map the SSL certificate of the server as a ${database_username} user":


### PR DESCRIPTION
We have updated to Puppet 8.2 and in the release notes it states that PostgreSQL 13 is not supported. The most current version for us is PostgreSQL 15, but we run into a problem with the Puppetforge module for Puppet DB.

The clientcert=1 parameter in the pg_hba.conf is not valid anymore.
This should be clientcert=verify-ca or clientcert=verify-full.