### PR TITLE
Fix: Unterminated quoted string when creating read user

### DIFF
--- a/manifests/database/default_read_grant.pp
+++ b/manifests/database/default_read_grant.pp
@@ -20,7 +20,7 @@ define puppetdb::database::default_read_grant (
                   acl.defaclacl
                 FROM pg_default_acl acl
                 JOIN pg_namespace ns ON acl.defaclnamespace=ns.oid
-                WHERE acl.defaclacl::text ~ '.*\\\\\"${database_read_only_username}\\\\\"=r/${database_username}\\\".*'
+                WHERE '@' || array_to_string(acl.defaclacl, '@') || '@' ~ '@(\"?)${database_read_only_username}\\1=r/(\"?)${database_username}\\2@'
                 AND nspname = '${schema}'",
   }
 
@@ -37,7 +37,7 @@ define puppetdb::database::default_read_grant (
                   acl.defaclacl
                 FROM pg_default_acl acl
                 JOIN pg_namespace ns ON acl.defaclnamespace=ns.oid
-                WHERE acl.defaclacl::text ~ '.*\\\\\"${database_read_only_username}\\\\\"=U/${database_username}\\\".*'
+                WHERE '@' || array_to_string(acl.defaclacl, '@') || '@' ~ '@(\"?)${database_read_only_username}\\1=U/(\"?)${database_username}\\2@'
                 AND nspname = '${schema}'",
   }
 
@@ -54,7 +54,7 @@ define puppetdb::database::default_read_grant (
                   acl.defaclacl
                 FROM pg_default_acl acl
                 JOIN pg_namespace ns ON acl.defaclnamespace=ns.oid
-                WHERE acl.defaclacl::text ~ '.*\\\\\"${database_read_only_username}\\\\\"=X/${database_username}\\\".*'
+                WHERE '@' || array_to_string(acl.defaclacl, '@') || '@' ~ '@(\"?)${database_read_only_username}\\1=X/(\"?)${database_username}\\2@'
                 AND nspname = '${schema}'",
   }
 }

--- a/spec/support/unit/shared/database.rb
+++ b/spec/support/unit/shared/database.rb
@@ -72,7 +72,7 @@ shared_examples 'postgresql_psql default read grant' do
                   acl.defaclacl
                 FROM pg_default_acl acl
                 JOIN pg_namespace ns ON acl.defaclnamespace=ns.oid
-                WHERE acl.defaclacl::text ~ '.*\\\\\"#{with[:database_read_only_username]}\\\\\"=r/#{with[:database_username]}\\\".*'
+                WHERE '@' || array_to_string(acl.defaclacl, '@') || '@' ~ '@(\"?)#{with[:database_read_only_username]}\\1=r/(\"?)#{with[:database_username]}\\2@'
                 AND nspname = 'public'",
       )
   }
@@ -92,7 +92,7 @@ shared_examples 'postgresql_psql default read grant' do
                   acl.defaclacl
                 FROM pg_default_acl acl
                 JOIN pg_namespace ns ON acl.defaclnamespace=ns.oid
-                WHERE acl.defaclacl::text ~ '.*\\\\\"#{with[:database_read_only_username]}\\\\\"=U/#{with[:database_username]}\\\".*'
+                WHERE '@' || array_to_string(acl.defaclacl, '@') || '@' ~ '@(\"?)#{with[:database_read_only_username]}\\1=U/(\"?)#{with[:database_username]}\\2@'
                 AND nspname = 'public'",
       )
   }
@@ -112,7 +112,7 @@ shared_examples 'postgresql_psql default read grant' do
                   acl.defaclacl
                 FROM pg_default_acl acl
                 JOIN pg_namespace ns ON acl.defaclnamespace=ns.oid
-                WHERE acl.defaclacl::text ~ '.*\\\\\"#{with[:database_read_only_username]}\\\\\"=X/#{with[:database_username]}\\\".*'
+                WHERE '@' || array_to_string(acl.defaclacl, '@') || '@' ~ '@(\"?)#{with[:database_read_only_username]}\\1=X/(\"?)#{with[:database_username]}\\2@'
                 AND nspname = 'public'",
       )
   }


### PR DESCRIPTION
puppetdb in default config will create a read-only user, however there is a bug[1] with the syntax to set the default read grant.

Fix it with help from comments[2].

[1] https://github.com/puppetlabs/puppetlabs-puppetdb/pull/330#issuecomment-935496488
[2] https://github.com/puppetlabs/puppetlabs-puppetdb/pull/339#issuecomment-1163552126