### PR TITLE
(BACKWARDS-INCOMPATIBLE) Update firewall manifests to use `jump` instead of `action`

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -17,8 +17,6 @@ fixtures:
     postgresql:
       repo: 'https://github.com/puppetlabs/puppetlabs-postgresql.git'
       ref: 'v9.2.0'
-    firewall:
-      repo: 'https://github.com/puppetlabs/puppetlabs-firewall.git'
-      ref: 'v6.0.0'
+    firewall: 'https://github.com/puppetlabs/puppetlabs-firewall.git'
   symlinks:
     puppetdb: '#{source_dir}'

--- a/manifests/server/firewall.pp
+++ b/manifests/server/firewall.pp
@@ -11,17 +11,17 @@ class puppetdb::server::firewall (
 
   if ($open_http_port) {
     firewall { "${http_port} accept - puppetdb":
-      dport  => $http_port,
-      proto  => 'tcp',
-      jump   => 'accept',
+      dport => $http_port,
+      proto => 'tcp',
+      jump  => 'accept',
     }
   }
 
   if ($open_ssl_port) {
     firewall { "${ssl_port} accept - puppetdb":
-      dport  => $ssl_port,
-      proto  => 'tcp',
-      jump   => 'accept',
+      dport => $ssl_port,
+      proto => 'tcp',
+      jump  => 'accept',
     }
   }
 }

--- a/manifests/server/firewall.pp
+++ b/manifests/server/firewall.pp
@@ -13,7 +13,7 @@ class puppetdb::server::firewall (
     firewall { "${http_port} accept - puppetdb":
       dport  => $http_port,
       proto  => 'tcp',
-      action => 'accept',
+      jump   => 'accept',
     }
   }
 
@@ -21,7 +21,7 @@ class puppetdb::server::firewall (
     firewall { "${ssl_port} accept - puppetdb":
       dport  => $ssl_port,
       proto  => 'tcp',
-      action => 'accept',
+      jump   => 'accept',
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/firewall",
-      "version_requirement": ">= 1.1.3 < 7.0.0"
+      "version_requirement": ">= 7.0.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/spec/support/unit/shared/server.rb
+++ b/spec/support/unit/shared/server.rb
@@ -21,7 +21,7 @@ shared_examples 'puppetdb::server::firewall' do
       .with(
         dport: with[:http_port],
         proto: 'tcp',
-        action: 'accept',
+        jump: 'accept',
       )
   }
 
@@ -31,7 +31,7 @@ shared_examples 'puppetdb::server::firewall' do
       .with(
         dport: with[:ssl_port],
         proto: 'tcp',
-        action: 'accept',
+        jump: 'accept',
       )
   }
 end


### PR DESCRIPTION
As part of the Firewall module rewrite the functionality of the `action` attribute has been rolled into the `jump` attribute, the two of them both managing the Firewall jump value.