### PR TITLE
make puppet_confdir configurable

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -2,6 +2,7 @@
 class puppetdb::globals (
   $version                      = 'present',
   $database                     = 'postgres',
+  Stdlib::Absolutepath $puppet_confdir = $settings::confdir,
   ) {
 
   if !(fact('os.family') in ['RedHat', 'Suse', 'Archlinux', 'Debian', 'OpenBSD', 'FreeBSD']) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -91,21 +91,21 @@ class puppetdb::params inherits puppetdb::globals {
         $etcdir                 = '/etc/puppetdb'
         $vardir                 = '/var/lib/puppetdb'
         $database_embedded_path = "${vardir}/db/db"
-        $puppet_confdir         = pick($settings::confdir,'/etc/puppet')
+        $puppet_confdir         = pick($puppetdb::globals::puppet_confdir,'/etc/puppet')
         $puppet_service_name    = 'puppetmaster'
       }
       'OpenBSD': {
         $etcdir                 = '/etc/puppetdb'
         $vardir                 = '/var/db/puppetdb'
         $database_embedded_path = "${vardir}/db/db"
-        $puppet_confdir         = pick($settings::confdir,'/etc/puppet')
+        $puppet_confdir         = pick($puppetdb::globals::puppet_confdir,'/etc/puppet')
         $puppet_service_name    = 'puppetmasterd'
       }
       'FreeBSD': {
         $etcdir                 = '/usr/local/etc/puppetdb'
         $vardir                 = '/var/db/puppetdb'
         $database_embedded_path = "${vardir}/db/db"
-        $puppet_confdir         = pick($settings::confdir,'/usr/local/etc/puppet')
+        $puppet_confdir         = pick($puppetdb::globals::puppet_confdir,'/usr/local/etc/puppet')
         $puppet_service_name    = 'puppetmaster'
       }
       default: {
@@ -118,17 +118,17 @@ class puppetdb::params inherits puppetdb::globals {
     case fact('os.family') {
       'RedHat', 'Suse', 'Archlinux','Debian': {
         $etcdir              = '/etc/puppetlabs/puppetdb'
-        $puppet_confdir      = pick($settings::confdir,'/etc/puppetlabs/puppet')
+        $puppet_confdir      = pick($puppetdb::globals::puppet_confdir,'/etc/puppetlabs/puppet')
         $puppet_service_name = 'puppetserver'
       }
       'OpenBSD': {
         $etcdir              = '/etc/puppetlabs/puppetdb'
-        $puppet_confdir      = pick($settings::confdir,'/etc/puppetlabs/puppet')
+        $puppet_confdir      = pick($puppetdb::globals::puppet_confdir,'/etc/puppetlabs/puppet')
         $puppet_service_name = undef
       }
       'FreeBSD': {
         $etcdir              = '/usr/local/etc/puppetlabs/puppetdb'
-        $puppet_confdir      = pick($settings::confdir,'/usr/local/etc/puppetlabs/puppet')
+        $puppet_confdir      = pick($puppetdb::globals::puppet_confdir,'/usr/local/etc/puppetlabs/puppet')
         $puppet_service_name = undef
       }
       default: {


### PR DESCRIPTION
$settings::<> vars should generally be configurable because they hold the compilers value. This can be a problem if for example you're trying to use this module with Bolt, which returns a temp directory.

I'm not a fan of the globals (or params) class, but this gets the job done in lieu of overhauling the module to meet current standards.

_Hopefully issues can be enabled soon so we can start collaborating on bringing this module into the current century._