### PR TITLE
Change default postgres version to 14

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -14,9 +14,7 @@ fixtures:
     augeas_core: 'https://github.com/puppetlabs/puppetlabs-augeas_core.git'
     postgresql: 'https://github.com/puppetlabs/puppetlabs-postgresql.git'
     firewall: 'https://github.com/puppetlabs/puppetlabs-firewall.git'
-    postgresql:
-      repo: 'https://github.com/puppetlabs/puppetlabs-postgresql.git'
-      ref: 'v9.2.0'
+    postgresql: 'https://github.com/puppetlabs/puppetlabs-postgresql.git'
     firewall: 'https://github.com/puppetlabs/puppetlabs-firewall.git'
   symlinks:
     puppetdb: '#{source_dir}'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,11 +24,7 @@ class puppetdb::params inherits puppetdb::globals {
     $manage_pg_repo            = false
   }
 
-  if $puppetdb_version in ['latest','present'] or versioncmp($puppetdb_version, '7.0.0') >= 0 {
-    $postgres_version          = '11'
-  } else {
-    $postgres_version          = '9.6'
-  }
+  $postgres_version          = '14'
 
   $puppetdb_major_version = $puppetdb_version ? {
     'latest'  => '8',

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/postgresql",
-      "version_requirement": ">= 6.5.0 < 10.0.0"
+      "version_requirement": ">= 6.5.0 < 11.0.0"
     },
     {
       "name": "puppetlabs/firewall",

--- a/spec/acceptance/standalone_spec.rb
+++ b/spec/acceptance/standalone_spec.rb
@@ -6,8 +6,7 @@ describe 'standalone' do
   let(:puppetdb_params) {}
   let(:puppetdb_master_config_params) {}
 
-  # TODO: temporary work-around for EL installs
-  let(:postgres_version) { "(getvar('facts.os.family') == 'RedHat') ? { true => '12', default => undef }" }
+  let(:postgres_version) { 'undef' } # default
   let(:manage_firewall) { "(getvar('facts.os.family') == 'RedHat' and Integer(getvar('facts.os.release.major')) > 7)" }
 
   describe 'with defaults' do

--- a/spec/support/acceptance/shared/puppetdb.rb
+++ b/spec/support/acceptance/shared/puppetdb.rb
@@ -3,19 +3,7 @@
 shared_examples 'puppetdb' do
   let(:pp) do
     <<~PP
-    # FIXME: temporary work-around for EL installs
     if $facts['os']['family'] == 'RedHat' {
-      $gpg_key_file = $facts['os']['release']['major'] ? {
-        '7'     => 'PGDG-RPM-GPG-KEY-RHEL7',
-        default => 'PGDG-RPM-GPG-KEY-RHEL',
-      }
-      file { "/etc/pki/rpm-gpg/${gpg_key_file}":
-        source => "https://download.postgresql.org/pub/repos/yum/keys/${gpg_key_file}",
-      }
-      -> Yumrepo <| tag == 'postgresql::repo' |> {
-        gpgkey => "file:///etc/pki/rpm-gpg/${gpg_key_file}",
-      }
-
       # Work-around EL systemd in docker bug affecting forked services
       file_line { 'puppetdb-unit-remove-pidfile':
         path               => '/lib/systemd/system/puppetdb.service',

--- a/spec/support/unit/shared/database.rb
+++ b/spec/support/unit/shared/database.rb
@@ -220,7 +220,7 @@ shared_examples 'puppetdb::database::default_read_grant' do |error|
 end
 
 shared_examples 'puppetdb::database::postgresql_ssl_rules' do |error|
-  let(:defaults) { {} }
+  let(:defaults) { { postgres_version: '14' } }
   let(:with) { defined?(args) ? defaults.merge(args) : defaults }
 
   if error

--- a/spec/unit/classes/database/postgresql_spec.rb
+++ b/spec/unit/classes/database/postgresql_spec.rb
@@ -94,7 +94,7 @@ describe 'puppetdb::database::postgresql', type: :class do
           {
             read_database_username: params[:read_database_username],
             database_name:          params[:database_name],
-            password_hash:          'md588e898a4bade3fe1c9b96f650ec85900', # TODO: mock properly
+            password_hash:          %r{^(md5|SCRAM)}, # TODO: mock properly
             database_owner:         params[:database_username],
           }
         end


### PR DESCRIPTION
Postgres 11 is no longer supported as an installation method from Postgres.org. As a result, installations will fail using `puppetlabs-postgresql` with failures like:

```
   Error: /Stage[main]/Postgresql::Server::Install/Package[postgresql-server]/ensure: change from 'purged' to 'present' failed: Execution of '/usr/bin/yum -d 0 -e 0 -y install postgresql11-server' returned 1: One of the configured repositories failed (PostgreSQL 11 7 - x86_64),
     and yum doesn't have enough cached data to continue. At this point the only
     safe thing yum can do is fail. There are a few ways to work "fix" this:

         1. Contact the upstream for the repository and get them to fix the problem.

         2. Reconfigure the baseurl/etc. for the repository, to point to a working
            upstream. This is most often useful if you are using a newer
            distribution release than is supported by the repository (and the
            packages for the previous distribution release still work).

         3. Disable the repository, so yum won't use it by default. Yum will then
            just ignore the repository until you permanently enable it again or use
            --enablerepo for temporary usage:

                yum-config-manager --disable yum.postgresql.org

         4. Configure the failing repository to be skipped, if it is unavailable.
            Note that yum will try to contact the repo. when it runs most commands,
            so will have to try and fail each time (and thus. yum will be be much
            slower). If it is a very temporary problem though, this is often a nice
            compromise:

                yum-config-manager --save --setopt=yum.postgresql.org.skip_if_unavailable=true

    failure: repodata/repomd.xml from yum.postgresql.org: [Errno 256] No more mirrors to try.
    https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-7-x86_64/repodata/repomd.xml: [Errno 14] HTTPS Error 404 - Not Found
```

To make matters more complicated, `puppetlabs-postgresql` is impacted by https://yum.postgresql.org/news/pgdg-rpm-repo-gpg-key-update/

see https://github.com/puppetlabs/puppetlabs-postgresql/issues/1565

so this too will not work until a new version of that is released with a fix.