### PR TITLE
use the correct value for clientcert in pg_hba.conf for Postgresql 12

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -117,7 +117,7 @@ class puppetdb::database::postgresql (
         postgresql_ssl_cert_path    => $postgresql_ssl_cert_path,
         postgresql_ssl_ca_cert_path => $postgresql_ssl_ca_cert_path,
         postgres_version            => $postgres_version,
-        create_read_user_rule       => $create_read_user_rule
+        create_read_user_rule       => $create_read_user_rule,
       }
     }
 

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -116,7 +116,8 @@ class puppetdb::database::postgresql (
         postgresql_ssl_key_path     => $postgresql_ssl_key_path,
         postgresql_ssl_cert_path    => $postgresql_ssl_cert_path,
         postgresql_ssl_ca_cert_path => $postgresql_ssl_ca_cert_path,
-        create_read_user_rule       => $create_read_user_rule,
+        postgres_version            => $postgres_version,
+        create_read_user_rule       => $create_read_user_rule
       }
     }
 

--- a/manifests/database/postgresql_ssl_rules.pp
+++ b/manifests/database/postgresql_ssl_rules.pp
@@ -4,7 +4,7 @@
 define puppetdb::database::postgresql_ssl_rules (
   String $database_name,
   String $database_username,
-  String $postgres_version,
+  String[2,3] $postgres_version,
   String $puppetdb_server,
 ) {
   $identity_map_key = "${database_name}-${database_username}-map"

--- a/manifests/database/postgresql_ssl_rules.pp
+++ b/manifests/database/postgresql_ssl_rules.pp
@@ -4,9 +4,15 @@
 define puppetdb::database::postgresql_ssl_rules (
   String $database_name,
   String $database_username,
+  String $postgres_version,
   String $puppetdb_server,
 ) {
   $identity_map_key = "${database_name}-${database_username}-map"
+
+  $clientcert_value = Float($postgres_version) >= 12.0 ? {
+    true    => 'verify-full',
+    false   => '1',
+  }
 
   postgresql::server::pg_hba_rule { "Allow certificate mapped connections to ${database_name} as ${database_username} (ipv4)":
     type        => 'hostssl',
@@ -15,7 +21,7 @@ define puppetdb::database::postgresql_ssl_rules (
     address     => '0.0.0.0/0',
     auth_method => 'cert',
     order       => 0,
-    auth_option => "map=${identity_map_key} clientcert=1",
+    auth_option => "map=${identity_map_key} clientcert=${clientcert_value}",
   }
 
   postgresql::server::pg_hba_rule { "Allow certificate mapped connections to ${database_name} as ${database_username} (ipv6)":
@@ -25,7 +31,7 @@ define puppetdb::database::postgresql_ssl_rules (
     address     => '::0/0',
     auth_method => 'cert',
     order       => 0,
-    auth_option => "map=${identity_map_key} clientcert=1",
+    auth_option => "map=${identity_map_key} clientcert=${clientcert_value}",
   }
 
   postgresql::server::pg_ident_rule { "Map the SSL certificate of the server as a ${database_username} user":

--- a/manifests/database/ssl_configuration.pp
+++ b/manifests/database/ssl_configuration.pp
@@ -10,6 +10,7 @@ class puppetdb::database::ssl_configuration (
   $postgresql_ssl_key_path     = $puppetdb::params::postgresql_ssl_key_path,
   $postgresql_ssl_cert_path    = $puppetdb::params::postgresql_ssl_cert_path,
   $postgresql_ssl_ca_cert_path = $puppetdb::params::postgresql_ssl_ca_cert_path,
+  $postgres_version            = $puppetdb::params::postgres_version,
   $create_read_user_rule       = false,
 ) inherits puppetdb::params {
   File {
@@ -56,6 +57,7 @@ class puppetdb::database::ssl_configuration (
   puppetdb::database::postgresql_ssl_rules { "Configure postgresql ssl rules for ${database_username}":
     database_name     => $database_name,
     database_username => $database_username,
+    postgres_version  => $postgres_version,
     puppetdb_server   => $puppetdb_server,
   }
 
@@ -63,6 +65,7 @@ class puppetdb::database::ssl_configuration (
     puppetdb::database::postgresql_ssl_rules { "Configure postgresql ssl rules for ${read_database_username}":
       database_name     => $database_name,
       database_username => $read_database_username,
+      postgres_version  => $postgres_version,
       puppetdb_server   => $puppetdb_server,
     }
   }

--- a/spec/defines/database/postgresql_ssl_rules_spec.rb
+++ b/spec/defines/database/postgresql_ssl_rules_spec.rb
@@ -6,11 +6,28 @@ valid = {
   'puppetdb-read': {
     database_name:     'puppetdb',
     database_username: 'monitor',
+    postgres_version: '11',
     puppetdb_server:   'localhost',
   },
   'monitor': {
     database_name:     'opensesame',
     database_username: 'grover',
+    postgres_version: '11',
+    puppetdb_server:   'rainbow',
+  },
+}
+
+valid_12plus = {
+  'puppetdb-read': {
+    database_name:     'puppetdb',
+    database_username: 'monitor',
+    postgres_version: '12',
+    puppetdb_server:   'localhost',
+  },
+  'monitor': {
+    database_name:     'opensesame',
+    database_username: 'grover',
+    postgres_version: '12',
     puppetdb_server:   'rainbow',
   },
 }
@@ -27,6 +44,15 @@ describe 'puppetdb::database::postgresql_ssl_rules' do
 
   valid.each do |name, params|
     context "for valid #{name}" do
+      include_examples 'puppetdb::database::postgresql_ssl_rules' do
+        let(:title) { name.to_s }
+        let(:params) { params }
+      end
+    end
+  end
+
+  valid_12plus.each do |name, params|
+    context "for valid_12plus #{name}" do
       include_examples 'puppetdb::database::postgresql_ssl_rules' do
         let(:title) { name.to_s }
         let(:params) { params }

--- a/spec/support/unit/shared/database.rb
+++ b/spec/support/unit/shared/database.rb
@@ -227,6 +227,7 @@ shared_examples 'puppetdb::database::postgresql_ssl_rules' do |error|
     it { is_expected.to raise_error(error) }
   else
     let(:identity_map_key) { "#{with[:database_name]}-#{with[:database_username]}-map" }
+    let(:client_cert) { (with[:postgres_version].to_f >= 12.0) ? 'verify-full' : '1' }
 
     it { is_expected.to contain_puppetdb__database__postgresql_ssl_rules(name).with(with) }
 
@@ -239,7 +240,7 @@ shared_examples 'puppetdb::database::postgresql_ssl_rules' do |error|
           address:     '0.0.0.0/0',
           auth_method: 'cert',
           order:       0,
-          auth_option: "map=#{identity_map_key} clientcert=1",
+          auth_option: "map=#{identity_map_key} clientcert=#{client_cert}",
         )
     }
 
@@ -252,7 +253,7 @@ shared_examples 'puppetdb::database::postgresql_ssl_rules' do |error|
           address:     '::0/0',
           auth_method: 'cert',
           order:       0,
-          auth_option: "map=#{identity_map_key} clientcert=1",
+          auth_option: "map=#{identity_map_key} clientcert=#{client_cert}",
         )
     }
 

--- a/spec/unit/classes/database/ssl_configuration_spec.rb
+++ b/spec/unit/classes/database/ssl_configuration_spec.rb
@@ -110,37 +110,5 @@ describe 'puppetdb::database::ssl_configuration', type: :class do
         end
       end
     end
-
-    context 'when the specified Postgresql version is 12 or later' do
-      let(:params) do
-        {
-          database_name: 'puppetdb',
-          database_username: 'puppetdb',
-          postgres_version: '12'
-        }
-      end
-
-      it 'has hba rule for puppetdb user ipv4' do
-        is_expected.to contain_postgresql__server__pg_hba_rule("Allow certificate mapped connections to #{params[:database_name]} as #{params[:database_username]} (ipv4)")
-          .with_type('hostssl')
-          .with_database(params[:database_name])
-          .with_user(params[:database_username])
-          .with_address('0.0.0.0/0')
-          .with_auth_method('cert')
-          .with_order(0)
-          .with_auth_option("map=#{identity_map} clientcert=verify-full")
-      end
-
-      it 'has hba rule for puppetdb user ipv6' do
-        is_expected.to contain_postgresql__server__pg_hba_rule("Allow certificate mapped connections to #{params[:database_name]} as #{params[:database_username]} (ipv6)")
-          .with_type('hostssl')
-          .with_database(params[:database_name])
-          .with_user(params[:database_username])
-          .with_address('::0/0')
-          .with_auth_method('cert')
-          .with_order(0)
-          .with_auth_option("map=#{identity_map} clientcert=verify-full")
-      end
-    end
   end
 end

--- a/spec/unit/classes/database/ssl_configuration_spec.rb
+++ b/spec/unit/classes/database/ssl_configuration_spec.rb
@@ -110,5 +110,37 @@ describe 'puppetdb::database::ssl_configuration', type: :class do
         end
       end
     end
+
+    context 'when the specified Postgresql version is 12 or later' do
+      let(:params) do
+        {
+          database_name: 'puppetdb',
+          database_username: 'puppetdb',
+          postgres_version: '12'
+        }
+      end
+
+      it 'has hba rule for puppetdb user ipv4' do
+        is_expected.to contain_postgresql__server__pg_hba_rule("Allow certificate mapped connections to #{params[:database_name]} as #{params[:database_username]} (ipv4)")
+          .with_type('hostssl')
+          .with_database(params[:database_name])
+          .with_user(params[:database_username])
+          .with_address('0.0.0.0/0')
+          .with_auth_method('cert')
+          .with_order(0)
+          .with_auth_option("map=#{identity_map} clientcert=verify-full")
+      end
+
+      it 'has hba rule for puppetdb user ipv6' do
+        is_expected.to contain_postgresql__server__pg_hba_rule("Allow certificate mapped connections to #{params[:database_name]} as #{params[:database_username]} (ipv6)")
+          .with_type('hostssl')
+          .with_database(params[:database_name])
+          .with_user(params[:database_username])
+          .with_address('::0/0')
+          .with_auth_method('cert')
+          .with_order(0)
+          .with_auth_option("map=#{identity_map} clientcert=verify-full")
+      end
+    end
   end
 end


### PR DESCRIPTION
12 and up, that is.

PuppetDB 8.0.0 requires Postgresql 14 or later, but starting in 12 the syntax for the clientcert option in pg_hba.conf changed. This PR implements the new syntax when a newer version of Postgresql is requested by the user.