### PR TITLE
Fix custom database port support

### DIFF
--- a/manifests/database/default_read_grant.pp
+++ b/manifests/database/default_read_grant.pp
@@ -6,9 +6,11 @@ define puppetdb::database::default_read_grant (
   String $schema,
   String $database_username,
   String $database_read_only_username,
+  Optional[Stdlib::Port] $database_port = undef,
 ) {
   postgresql_psql { "grant default select permission for ${database_read_only_username}":
     db      => $database_name,
+    port    => $database_port,
     command => "ALTER DEFAULT PRIVILEGES
                   FOR USER \"${database_username}\"
                   IN SCHEMA \"${schema}\"
@@ -26,6 +28,7 @@ define puppetdb::database::default_read_grant (
 
   postgresql_psql { "grant default usage permission for ${database_read_only_username}":
     db      => $database_name,
+    port    => $database_port,
     command => "ALTER DEFAULT PRIVILEGES
                   FOR USER \"${database_username}\"
                   IN SCHEMA \"${schema}\"
@@ -43,6 +46,7 @@ define puppetdb::database::default_read_grant (
 
   postgresql_psql { "grant default execute permission for ${database_read_only_username}":
     db      => $database_name,
+    port    => $database_port,
     command => "ALTER DEFAULT PRIVILEGES
                   FOR USER \"${database_username}\"
                   IN SCHEMA \"${schema}\"

--- a/manifests/database/read_grant.pp
+++ b/manifests/database/read_grant.pp
@@ -5,9 +5,11 @@ define puppetdb::database::read_grant (
   String $database_name,
   String $schema,
   String $database_read_only_username,
+  Optional[Stdlib::Port] $database_port = undef,
 ) {
   postgresql_psql { "grant select permission for ${database_read_only_username}":
     db      => $database_name,
+    port    => $database_port,
     command => "GRANT SELECT
                 ON ALL TABLES IN SCHEMA \"${schema}\"
                 TO \"${database_read_only_username}\"",
@@ -22,6 +24,7 @@ define puppetdb::database::read_grant (
 
   postgresql_psql { "grant usage permission for ${database_read_only_username}":
     db      => $database_name,
+    port    => $database_port,
     command => "GRANT USAGE
                 ON ALL SEQUENCES IN SCHEMA \"${schema}\"
                 TO \"${database_read_only_username}\"",
@@ -36,6 +39,7 @@ define puppetdb::database::read_grant (
 
   postgresql_psql { "grant execution permission for ${database_read_only_username}":
     db      => $database_name,
+    port    => $database_port,
     command => "GRANT EXECUTE
                 ON ALL FUNCTIONS IN SCHEMA \"${schema}\"
                 TO \"${database_read_only_username}\"",

--- a/manifests/database/read_only_user.pp
+++ b/manifests/database/read_only_user.pp
@@ -20,15 +20,18 @@ define puppetdb::database::read_only_user (
   String $database_name,
   String $database_owner,
   Variant[String, Boolean] $password_hash = false,
+  Optional[Stdlib::Port] $database_port = undef,
 ) {
   postgresql::server::role { $read_database_username:
     password_hash => $password_hash,
+    port          => $database_port,
   }
 
   -> postgresql::server::database_grant { "${database_name} grant connection permission to ${read_database_username}":
     privilege => 'CONNECT',
     db        => $database_name,
     role      => $read_database_username,
+    port      => $database_port,
   }
 
   -> puppetdb::database::default_read_grant {
@@ -36,6 +39,7 @@ define puppetdb::database::read_only_user (
       database_username           => $database_owner,
       database_read_only_username => $read_database_username,
       database_name               => $database_name,
+      database_port               => $database_port,
       schema                      => 'public',
   }
 
@@ -43,6 +47,7 @@ define puppetdb::database::read_only_user (
     "${database_name} grant read-only permission on existing objects to ${read_database_username}":
       database_read_only_username => $read_database_username,
       database_name               => $database_name,
+      database_port               => $database_port,
       schema                      => 'public',
   }
 }

--- a/spec/acceptance/standalone_spec.rb
+++ b/spec/acceptance/standalone_spec.rb
@@ -105,4 +105,23 @@ describe 'standalone' do
       it { is_expected.to be_running }
     end
   end
+
+  describe 'supports changing database port', :change do
+    let(:puppetdb_params) do
+      <<~EOS
+        database_port           => '5433',
+        read_database_port      => '5433',
+      EOS
+    end
+
+    it_behaves_like 'puppetdb'
+
+    describe port(5433), :status do
+      it { is_expected.to be_listening }
+    end
+
+    describe service('puppetdb') do
+      it { is_expected.to be_running }
+    end
+  end
 end

--- a/spec/defines/database/default_read_grant_spec.rb
+++ b/spec/defines/database/default_read_grant_spec.rb
@@ -3,13 +3,15 @@
 require 'spec_helper'
 
 describe 'puppetdb::database::default_read_grant' do
+  defaults = {
+    database_name:               'puppetdb',
+    schema:                      'public',
+    database_username:           'puppetdb',
+    database_read_only_username: 'puppetdb-read',
+  }
   valid = {
-    'standard': {
-      database_name:               'puppetdb',
-      schema:                      'public',
-      database_username:           'puppetdb',
-      database_read_only_username: 'puppetdb-read',
-    }
+    'standard': defaults,
+    'standard with port': defaults.merge({ database_port: 5433 }),
   }
 
   invalid = {
@@ -18,7 +20,8 @@ describe 'puppetdb::database::default_read_grant' do
       schema:                      'public',
       database_username:           'puppetdb',
       database_read_only_username: 'puppetdb-read',
-    }
+    },
+    'invalid data type': defaults.merge({ database_port: '5433' }),
   }
 
   let(:facts) { on_supported_os.take(1).first[1] }

--- a/spec/defines/database/read_grant_spec.rb
+++ b/spec/defines/database/read_grant_spec.rb
@@ -2,16 +2,20 @@
 
 require 'spec_helper'
 
+defaults = {
+  database_read_only_username: 'puppetdb-read',
+  database_name:               'puppetdb',
+  schema:                      'public',
+}
+
 valid = {
-  'grant read on new objects from blah to blah': {
-    database_read_only_username: 'puppetdb-read',
-    database_name:               'puppetdb',
-    schema:                      'public',
-  },
+  'grant read on new objects from blah to blah': defaults,
+  'grant read on new objects from blah to blah with port': defaults.merge({ database_port: 5433 }),
 }
 
 invalid = {
   'no params': {},
+  'invalid data type': defaults.merge({ database_port: '5433' }),
 }
 
 describe 'puppetdb::database::read_grant' do

--- a/spec/defines/database/read_only_user_spec.rb
+++ b/spec/defines/database/read_only_user_spec.rb
@@ -2,22 +2,25 @@
 
 require 'spec_helper'
 
+defaults = {
+  read_database_username: 'puppetdb-read',
+  database_name:          'puppetdb',
+  database_owner:         'puppetdb',
+}
+
 valid = {
-  'puppetdb-read': {
-    read_database_username: 'puppetdb-read',
-    database_name:          'puppetdb',
-    password_hash:          'blah',
-    database_owner:         'puppetdb',
-  },
+  'puppetdb-read': defaults.merge({ password_hash: 'blash' }),
   'spectest': {
     read_database_username: 'spectest-read',
     database_name:          'spectest',
     database_owner:         'spectest',
   },
+  'with port': defaults.merge({ database_port: 5433 }),
 }
 
 invalid = {
   'no params': {},
+  'invalid data type': defaults.merge({ database_port: '5433' }),
 }
 
 describe 'puppetdb::database::read_only_user', type: :define do

--- a/spec/support/acceptance/shared/puppetdb.rb
+++ b/spec/support/acceptance/shared/puppetdb.rb
@@ -45,4 +45,8 @@ shared_examples 'puppetdb' do
   it 'applies idempotently' do
     idempotent_apply(pp, debug: ENV.key?('DEBUG'))
   end
+
+  it 'agent can puppetdb_query' do
+    apply_manifest("$envs = puppetdb_query('environments[name]{}')", expect_failures: false, debug: ENV.key?('DEBUG'))
+  end
 end

--- a/spec/unit/classes/database/postgresql_spec.rb
+++ b/spec/unit/classes/database/postgresql_spec.rb
@@ -51,6 +51,7 @@ describe 'puppetdb::database::postgresql', type: :class do
           database_password: 'puppetdb',
           read_database_username: 'puppetdb-read',
           read_database_password: 'puppetdb-read',
+          database_port: '5432',
         }
       end
 
@@ -60,6 +61,7 @@ describe 'puppetdb::database::postgresql', type: :class do
             user:     params[:database_username],
             password: params[:database_password],
             grant:    'all',
+            port:     params[:database_port].to_i,
           )
       }
 
@@ -68,6 +70,7 @@ describe 'puppetdb::database::postgresql', type: :class do
           .that_requires("Postgresql::Server::Db[#{params[:database_name]}]")
           .with(
             db:      params[:database_name],
+            port:    params[:database_port].to_i,
             command: 'REVOKE CREATE ON SCHEMA public FROM public',
             unless:  "SELECT * FROM
                   (SELECT has_schema_privilege('public', 'public', 'create') can_create) privs
@@ -81,6 +84,7 @@ describe 'puppetdb::database::postgresql', type: :class do
           .that_comes_before("Puppetdb::Database::Read_only_user[#{params[:read_database_username]}]")
           .with(
             db:      params[:database_name],
+            port:    params[:database_port].to_i,
             command: "GRANT CREATE ON SCHEMA public TO \"#{params[:database_username]}\"",
             unless:  "SELECT * FROM
                   (SELECT has_schema_privilege('#{params[:database_username]}', 'public', 'create') can_create) privs
@@ -96,6 +100,7 @@ describe 'puppetdb::database::postgresql', type: :class do
             database_name:          params[:database_name],
             password_hash:          %r{^(md5|SCRAM)}, # TODO: mock properly
             database_owner:         params[:database_username],
+            database_port:          params[:database_port].to_i,
           }
         end
       end
@@ -105,6 +110,7 @@ describe 'puppetdb::database::postgresql', type: :class do
           .that_requires("Puppetdb::Database::Read_only_user[#{params[:read_database_username]}]")
           .with(
             db:      params[:database_name],
+            port:    params[:database_port].to_i,
             command: "GRANT \"#{params[:read_database_username]}\" TO \"#{params[:database_username]}\"",
             unless:  "SELECT oid, rolname FROM pg_roles WHERE
                    pg_has_role( '#{params[:database_username]}', oid, 'member') and rolname = '#{params[:read_database_username]}'",


### PR DESCRIPTION
Very helpful to be able to switch ports on a major version change.

Found while testing upgrading from 7.14.0 to 8.0.0 (to be released) of this module
Testing also revealed, deploying to an existing setup (eg. puppetdb + postgresql 11), postgresql 14 server will be deployed but unable to start (port in use by postgresql 11).