### PR TITLE
Allow puppetlabs/firewall 8.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/firewall",
-      "version_requirement": ">= 7.0.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
puppetlabs/firewall has moved up to 8.x, mark this as allowed to use it.