### PR TITLE
Support scram-sha-256 password_encryption method

### DIFF
--- a/manifests/database/read_only_user.pp
+++ b/manifests/database/read_only_user.pp
@@ -13,18 +13,22 @@
 #   The user which owns the database (i.e. the migration user for the database).
 # @param password_hash
 #   The value of $_database_password in app_database.
+# @param password_encryption
+#   The hash method for postgresql password, since PostgreSQL 14 default is `scram-sha-256`.
 #
 # @api private
 define puppetdb::database::read_only_user (
   String $read_database_username,
   String $database_name,
   String $database_owner,
-  Variant[String, Boolean] $password_hash = false,
+  Variant[String, Boolean, Sensitive[String]] $password_hash = false,
   Optional[Stdlib::Port] $database_port = undef,
+  Optional[Postgresql::Pg_password_encryption] $password_encryption = undef,
 ) {
   postgresql::server::role { $read_database_username:
     password_hash => $password_hash,
     port          => $database_port,
+    hash          => $password_encryption,
   }
 
   -> postgresql::server::database_grant { "${database_name} grant connection permission to ${read_database_username}":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -374,6 +374,9 @@
 # @param java_bin
 #   java binary path for PuppetDB. If undef, default will be used.
 #
+# @param postgresql_password_encryption
+#   PostgreSQL password authentication method, either `md5` or `scram-sha-256`
+#
 class puppetdb (
   $listen_address                          = $puppetdb::params::listen_address,
   $listen_port                             = $puppetdb::params::listen_port,
@@ -460,6 +463,7 @@ class puppetdb (
   Boolean $automatic_dlo_cleanup           = $puppetdb::params::automatic_dlo_cleanup,
   String[1] $cleanup_timer_interval        = $puppetdb::params::cleanup_timer_interval,
   Integer[1] $dlo_max_age                  = $puppetdb::params::dlo_max_age,
+  Postgresql::Pg_password_encryption $postgresql_password_encryption = $puppetdb::params::password_encryption,
   Optional[Stdlib::Absolutepath] $java_bin = $puppetdb::params::java_bin,
 ) inherits puppetdb::params {
   class { 'puppetdb::server':
@@ -568,6 +572,7 @@ class puppetdb (
     read_database_username      => $read_database_username,
     read_database_password      => $read_database_password,
     read_database_host          => $read_database_host,
+    password_encryption         => $postgresql_password_encryption,
     before                      => $database_before,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,6 +42,7 @@ class puppetdb::params inherits puppetdb::globals {
   $database_validate      = true
   $database_max_pool_size = undef
   $puppetdb_server        = fact('networking.fqdn')
+  $password_encryption    = 'scram-sha-256'
 
   # These settings manage the various auto-deactivation and auto-purge settings
   $node_ttl               = '7d'

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/postgresql",
-      "version_requirement": ">= 6.5.0 < 11.0.0"
+      "version_requirement": ">= 9.2.0 < 11.0.0"
     },
     {
       "name": "puppetlabs/firewall",

--- a/spec/unit/classes/init_spec.rb
+++ b/spec/unit/classes/init_spec.rb
@@ -67,6 +67,22 @@ describe 'puppetdb', type: :class do
         end
       end
 
+      context 'with password encryption' do
+        let :params do
+          {
+            postgresql_password_encryption: 'md5',
+          }
+        end
+
+        it do
+          is_expected.to contain_postgresql__server__pg_hba_rule('allow access to all users for instance main')
+            .with_type('host')
+            .with_database('all')
+            .with_user('all')
+            .with_auth_method('md5')
+        end
+      end
+
       context 'when using ssl certificates' do
         let(:params) do
           {


### PR DESCRIPTION
PostgreSQL module uses by default `scram-sha-256` password [encryption for PostgreSQL databases since 14](https://github.com/puppetlabs/puppetlabs-postgresql/commit/43c21aff1a1e07d8bdc2da211e3503a973ae4034) - introduced in `puppetlabs-postgresql == 10.1.0`. At least `puppetlabs-postgresql >= 9.2` [is needed](https://github.com/puppetlabs/puppetlabs-postgresql/commit/985309e2df83aa16b1b5430ef1607eca56981de7). 


This PR introduces new parameter `postgresql_password_encryption`, to apply the old (less secure behavior) use:

```yaml
puppetdb::postgresql_password_encryption: 'md5'
```
In order to use modern password auth, the hba rules and password function requires passing the `password_encryption` parameter.

Related issues: 
 - #394 