### PR TITLE
Fix lower bound the of puppetlabs-postgresql dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/postgresql",
-      "version_requirement": ">= 9.2.0 < 11.0.0"
+      "version_requirement": ">= 10.0.0 < 11.0.0"
     },
     {
       "name": "puppetlabs/firewall",


### PR DESCRIPTION
The changes introduced in #392 require changes that where introduced in
version 10.0.0 of the puppetlabs-postgresql module, but the lower
version of the module was not properly updated in this PR.

Fix the lower bound of the dependency to indicate that version 10 of the
puppetlabs-postgresql module is required for proper operation.

Fixes #401
