### PR TITLE
Add a `puppetdb_version` fact with PuppetDB version

### DIFF
--- a/lib/facter/puppetdb_version.rb
+++ b/lib/facter/puppetdb_version.rb
@@ -3,11 +3,6 @@ Facter.add(:puppetdb_version) do
 
   setcode do
     output = Facter::Core::Execution.execute('puppetdb --version')
-
-    if output.nil?
-      nil
-    else
-      output.split(':').last.strip
-    end
+    output.split(':').last.strip
   end
 end

--- a/lib/facter/puppetdb_version.rb
+++ b/lib/facter/puppetdb_version.rb
@@ -1,0 +1,13 @@
+Facter.add(:puppetdb_version) do
+  confine { Facter::Util::Resolution.which('puppetdb') }
+
+  setcode do
+    output = Facter::Core::Execution.execute('puppetdb --version')
+
+    if output.nil?
+      nil
+    else
+      output.split(':').last.strip
+    end
+  end
+end

--- a/spec/unit/facter/puppetdb_version_spec.rb
+++ b/spec/unit/facter/puppetdb_version_spec.rb
@@ -22,11 +22,4 @@ describe 'puppetdb_version' do
 
     expect(Facter.fact(:puppetdb_version).value).to be_nil
   end
-
-  it 'returns nil if puppetdb version output is nil' do
-    allow(Facter::Util::Resolution).to receive(:which).with('puppetdb').and_return('/usr/bin/puppetdb')
-    allow(Facter::Core::Execution).to receive(:execute).with('puppetdb --version').and_return(nil)
-
-    expect(Facter.fact(:puppetdb_version).value).to be_nil
-  end
 end

--- a/spec/unit/facter/puppetdb_version_spec.rb
+++ b/spec/unit/facter/puppetdb_version_spec.rb
@@ -10,20 +10,20 @@ describe 'puppetdb_version' do
     Facter.clear
   end
 
-  it 'should return the correct puppetdb version' do
+  it 'returns the correct puppetdb version' do
     allow(Facter::Util::Resolution).to receive(:which).with('puppetdb').and_return('/usr/bin/puppetdb')
     allow(Facter::Core::Execution).to receive(:execute).with('puppetdb --version').and_return("puppetdb version: 7.18.0\n")
 
     expect(Facter.fact(:puppetdb_version).value).to eq('7.18.0')
   end
 
-  it 'should return nil if puppetdb command is not available' do
+  it 'returns nil if puppetdb command is not available' do
     allow(Facter::Util::Resolution).to receive(:which).with('puppetdb').and_return(nil)
 
     expect(Facter.fact(:puppetdb_version).value).to be_nil
   end
 
-  it 'should return nil if puppetdb version output is nil' do
+  it 'returns nil if puppetdb version output is nil' do
     allow(Facter::Util::Resolution).to receive(:which).with('puppetdb').and_return('/usr/bin/puppetdb')
     allow(Facter::Core::Execution).to receive(:execute).with('puppetdb --version').and_return(nil)
 

--- a/spec/unit/facter/puppetdb_version_spec.rb
+++ b/spec/unit/facter/puppetdb_version_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'facter'
+
+describe 'puppetdb_version' do
+  subject(:fact) { Facter.fact(:puppetdb_version) }
+
+  before(:each) do
+    Facter.clear
+  end
+
+  it 'should return the correct puppetdb version' do
+    allow(Facter::Util::Resolution).to receive(:which).with('puppetdb').and_return('/usr/bin/puppetdb')
+    allow(Facter::Core::Execution).to receive(:execute).with('puppetdb --version').and_return("puppetdb version: 7.18.0\n")
+
+    expect(Facter.fact(:puppetdb_version).value).to eq('7.18.0')
+  end
+
+  it 'should return nil if puppetdb command is not available' do
+    allow(Facter::Util::Resolution).to receive(:which).with('puppetdb').and_return(nil)
+
+    expect(Facter.fact(:puppetdb_version).value).to be_nil
+  end
+
+  it 'should return nil if puppetdb version output is nil' do
+    allow(Facter::Util::Resolution).to receive(:which).with('puppetdb').and_return('/usr/bin/puppetdb')
+    allow(Facter::Core::Execution).to receive(:execute).with('puppetdb --version').and_return(nil)
+
+    expect(Facter.fact(:puppetdb_version).value).to be_nil
+  end
+end


### PR DESCRIPTION
The code changes add a new Facter fact called `puppetdb_version` that retrieves the version of PuppetDB installed on the system. It uses the `puppetdb --version` command to fetch the version and returns it as a fact value.