### PR TITLE
Extend fact to not fail on debian packages

### DIFF
--- a/lib/facter/puppetdb_version.rb
+++ b/lib/facter/puppetdb_version.rb
@@ -5,7 +5,7 @@ Facter.add(:puppetdb_version) do
     require 'open3'
 
     # check if os is debian/ubuntu and the package is not from puppetlabs
-    if Facter.value(:osfamily) == 'Debian'
+    if Facter.value(:os)('family') == 'Debian'
       package_maintainer = Facter::Core::Execution.execute('apt-cache show puppetdb | grep "Maintainer:" | head -1')
       unless package_maintainer.include? 'Puppet Labs'
         output, status = Open3.capture2('dpkg-query --showformat=\'${Version}\' --show puppetdb')

--- a/lib/facter/puppetdb_version.rb
+++ b/lib/facter/puppetdb_version.rb
@@ -2,7 +2,26 @@ Facter.add(:puppetdb_version) do
   confine { Facter::Util::Resolution.which('puppetdb') }
 
   setcode do
-    output = Facter::Core::Execution.execute('puppetdb --version')
-    output.split(':').last.strip
+    require 'open3'
+
+    # check if os is debian/ubuntu and the package is not from puppetlabs
+    if Facter.value(:osfamily) == 'Debian'
+      package_maintainer = Facter::Core::Execution.execute('apt-cache show puppetdb | grep "Maintainer:" | head -1')
+      unless package_maintainer.include? 'Puppet Labs'
+        output, status = Open3.capture2('dpkg-query --showformat=\'${Version}\' --show puppetdb')
+        if status.success?
+          output.strip.split('-').first
+        else
+          nil
+        end
+      end
+    else
+      output, status = Open3.capture2('puppetdb --version')
+      if status.success?
+        output.split(':').last.strip
+      else
+        nil
+      end
+    end
   end
 end

--- a/lib/facter/puppetdb_version.rb
+++ b/lib/facter/puppetdb_version.rb
@@ -2,25 +2,9 @@ Facter.add(:puppetdb_version) do
   confine { Facter::Util::Resolution.which('puppetdb') }
 
   setcode do
-    command = 'puppetdb --version'
-    splitter = ':'
-    postion = 'last'
-
-    if Facter.value(:os)['family'] == 'Debian'
-      package_maintainer = Facter::Core::Execution.execute('apt-cache show puppetdb | grep "Maintainer:" | head -1')
-
-      unless package_maintainer.include? 'Puppet Labs'
-        command = 'dpkg-query --showformat=\'${Version}\' --show puppetdb'
-        splitter = '-'
-        postion = 'first'
-      end
-    end
-
-    begin
-      output = Facter::Core::Execution.execute(command)
-      output.split(splitter).send(postion).strip
-    rescue Facter::Core::Execution::ExecutionFailure
-      nil
-    end
+    output = Facter::Core::Execution.execute('puppetdb --version')
+    output.split(':').last.strip
+  rescue Facter::Core::Execution::ExecutionFailure
+    nil
   end
 end

--- a/spec/unit/facter/puppetdb_version_spec.rb
+++ b/spec/unit/facter/puppetdb_version_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'facter'
+require 'open3'
 
 describe 'puppetdb_version' do
   subject(:fact) { Facter.fact(:puppetdb_version) }

--- a/spec/unit/facter/puppetdb_version_spec.rb
+++ b/spec/unit/facter/puppetdb_version_spec.rb
@@ -10,11 +10,29 @@ describe 'puppetdb_version' do
     Facter.clear
   end
 
-  it 'returns the correct puppetdb version' do
+  it 'returns a version on non-Debian family with puppetlabs package' do
     allow(Facter::Util::Resolution).to receive(:which).with('puppetdb').and_return('/usr/bin/puppetdb')
-    allow(Facter::Core::Execution).to receive(:execute).with('puppetdb --version').and_return("puppetdb version: 7.18.0\n")
+    allow(Open3).to receive(:capture2).with('puppetdb --version').and_return("puppetdb version: 7.18.0\n")
 
     expect(Facter.fact(:puppetdb_version).value).to eq('7.18.0')
+  end
+
+  it 'returns a version on Debian family with non-puppetlabs package' do
+    allow(Facter::Util::Resolution).to receive(:which).with('puppetdb').and_return('/usr/sbin/puppetdb')
+    allow(Facter).to receive(:value).with(:osfamily).and_return('Debian')
+    allow(Facter::Core::Execution).to receive(:execute).with('apt-cache show puppetdb | grep "Maintainer:" | head -1').and_return('Maintainer: Ubuntu Developers')
+    allow(Open3).to receive(:capture2).with('dpkg-query --showformat=\'${Version}\' --show puppetdb').and_return("6.2.0-5")
+
+    expect(Facter.fact(:puppetdb_version).value).to eq('6.2.0')
+  end
+
+  it 'returns a version on Debian family with puppetlabs package' do
+    allow(Facter::Util::Resolution).to receive(:which).with('puppetdb').and_return('/usr/sbin/puppetdb')
+    allow(Facter).to receive(:value).with(:osfamily).and_return('Debian')
+    allow(Facter::Core::Execution).to receive(:execute).with('apt-cache show puppetdb | grep "Maintainer:" | head -1').and_return('Maintainer: Puppet Labs')
+    allow(Open3).to receive(:capture2).with('dpkg-query --showformat=\'${Version}\' --show puppetdb').and_return("7.19.0-1jammy")
+
+    expect(Facter.fact(:puppetdb_version).value).to eq('7.19.0')
   end
 
   it 'returns nil if puppetdb command is not available' do

--- a/spec/unit/facter/puppetdb_version_spec.rb
+++ b/spec/unit/facter/puppetdb_version_spec.rb
@@ -1,44 +1,93 @@
-# frozen_string_literal: true
-
-require 'spec_helper'
 require 'facter'
-require 'open3'
 
 describe 'puppetdb_version' do
-  subject(:fact) { Facter.fact(:puppetdb_version) }
-
   before(:each) do
     Facter.clear
   end
 
-  it 'returns a version on non-Debian family with puppetlabs package' do
-    allow(Facter::Util::Resolution).to receive(:which).with('puppetdb').and_return('/usr/bin/puppetdb')
-    allow(Open3).to receive(:capture2).with('puppetdb --version').and_return("puppetdb version: 7.18.0\n")
+  context 'when puppetdb is available' do
+    before do
+      allow(Facter::Util::Resolution).to receive(:which).with('puppetdb').and_return('/usr/bin/puppetdb')
+    end
 
-    expect(Facter.fact(:puppetdb_version).value).to eq('7.18.0')
+    context 'on a Debian-based system' do
+      before do
+        allow(Facter).to receive(:value).with(:os).and_return({ 'family' => 'Debian' })
+      end
+
+      context 'when Puppet Labs is the maintainer' do
+        before do
+          allow(Facter::Core::Execution).to receive(:execute)
+            .with('apt-cache show puppetdb | grep "Maintainer:" | head -1')
+            .and_return('Maintainer: Puppet Labs')
+        end
+
+        it 'returns the correct version from puppetdb --version' do
+          expect(Facter::Core::Execution).to receive(:execute)
+            .with('puppetdb --version')
+            .and_return('puppetdb version: 7.19.0')
+
+          expect(Facter.fact(:puppetdb_version).value).to eq('7.19.0')
+        end
+
+        it 'returns nil if the command execution fails' do
+          allow(Facter::Core::Execution).to receive(:execute).with('puppetdb --version').and_raise(Facter::Core::Execution::ExecutionFailure)
+
+          expect(Facter.fact(:puppetdb_version).value).to be_nil
+        end
+      end
+
+      context 'when Puppet Labs is not the maintainer' do
+        before do
+          allow(Facter::Core::Execution).to receive(:execute)
+            .with('apt-cache show puppetdb | grep "Maintainer:" | head -1')
+            .and_return('Maintainer: Other Maintainer')
+        end
+
+        it 'returns the correct version from dpkg-query' do
+          expect(Facter::Core::Execution).to receive(:execute)
+            .with("dpkg-query --showformat='${Version}' --show puppetdb")
+            .and_return('7.9.0-1ubuntu1')
+
+          expect(Facter.fact(:puppetdb_version).value).to eq('7.9.0')
+        end
+
+        it 'returns nil if the command execution fails' do
+          allow(Facter::Core::Execution).to receive(:execute).with("dpkg-query --showformat='${Version}' --show puppetdb").and_raise(Facter::Core::Execution::ExecutionFailure)
+
+          expect(Facter.fact(:puppetdb_version).value).to be_nil
+        end
+      end
+    end
+
+    context 'on a non-Debian-based system' do
+      before do
+        allow(Facter).to receive(:value).with(:os).and_return({ 'family' => 'RedHat' })
+      end
+
+      it 'returns the correct version from puppetdb --version' do
+        expect(Facter::Core::Execution).to receive(:execute)
+          .with('puppetdb --version')
+          .and_return('puppetdb version: 7.19.0')
+
+        expect(Facter.fact(:puppetdb_version).value).to eq('7.19.0')
+      end
+
+      it 'returns nil if the command execution fails' do
+        allow(Facter::Core::Execution).to receive(:execute).with('puppetdb --version').and_raise(Facter::Core::Execution::ExecutionFailure)
+
+        expect(Facter.fact(:puppetdb_version).value).to be_nil
+      end
+    end
   end
 
-  it 'returns a version on Debian family with non-puppetlabs package' do
-    allow(Facter::Util::Resolution).to receive(:which).with('puppetdb').and_return('/usr/sbin/puppetdb')
-    allow(Facter).to receive(:value).with(:osfamily).and_return('Debian')
-    allow(Facter::Core::Execution).to receive(:execute).with('apt-cache show puppetdb | grep "Maintainer:" | head -1').and_return('Maintainer: Ubuntu Developers')
-    allow(Open3).to receive(:capture2).with('dpkg-query --showformat=\'${Version}\' --show puppetdb').and_return("6.2.0-5")
+  context 'when puppetdb is not available' do
+    before do
+      allow(Facter::Util::Resolution).to receive(:which).with('puppetdb').and_return(nil)
+    end
 
-    expect(Facter.fact(:puppetdb_version).value).to eq('6.2.0')
-  end
-
-  it 'returns a version on Debian family with puppetlabs package' do
-    allow(Facter::Util::Resolution).to receive(:which).with('puppetdb').and_return('/usr/sbin/puppetdb')
-    allow(Facter).to receive(:value).with(:osfamily).and_return('Debian')
-    allow(Facter::Core::Execution).to receive(:execute).with('apt-cache show puppetdb | grep "Maintainer:" | head -1').and_return('Maintainer: Puppet Labs')
-    allow(Open3).to receive(:capture2).with('dpkg-query --showformat=\'${Version}\' --show puppetdb').and_return("7.19.0-1jammy")
-
-    expect(Facter.fact(:puppetdb_version).value).to eq('7.19.0')
-  end
-
-  it 'returns nil if puppetdb command is not available' do
-    allow(Facter::Util::Resolution).to receive(:which).with('puppetdb').and_return(nil)
-
-    expect(Facter.fact(:puppetdb_version).value).to be_nil
+    it 'returns nil' do
+      expect(Facter.fact(:puppetdb_version).value).to be_nil
+    end
   end
 end

--- a/spec/unit/facter/puppetdb_version_spec.rb
+++ b/spec/unit/facter/puppetdb_version_spec.rb
@@ -6,65 +6,11 @@ describe 'puppetdb_version' do
   end
 
   context 'when puppetdb is available' do
-    before do
+    before(:each) do
       allow(Facter::Util::Resolution).to receive(:which).with('puppetdb').and_return('/usr/bin/puppetdb')
     end
 
-    context 'on a Debian-based system' do
-      before do
-        allow(Facter).to receive(:value).with(:os).and_return({ 'family' => 'Debian' })
-      end
-
-      context 'when Puppet Labs is the maintainer' do
-        before do
-          allow(Facter::Core::Execution).to receive(:execute)
-            .with('apt-cache show puppetdb | grep "Maintainer:" | head -1')
-            .and_return('Maintainer: Puppet Labs')
-        end
-
-        it 'returns the correct version from puppetdb --version' do
-          expect(Facter::Core::Execution).to receive(:execute)
-            .with('puppetdb --version')
-            .and_return('puppetdb version: 7.19.0')
-
-          expect(Facter.fact(:puppetdb_version).value).to eq('7.19.0')
-        end
-
-        it 'returns nil if the command execution fails' do
-          allow(Facter::Core::Execution).to receive(:execute).with('puppetdb --version').and_raise(Facter::Core::Execution::ExecutionFailure)
-
-          expect(Facter.fact(:puppetdb_version).value).to be_nil
-        end
-      end
-
-      context 'when Puppet Labs is not the maintainer' do
-        before do
-          allow(Facter::Core::Execution).to receive(:execute)
-            .with('apt-cache show puppetdb | grep "Maintainer:" | head -1')
-            .and_return('Maintainer: Other Maintainer')
-        end
-
-        it 'returns the correct version from dpkg-query' do
-          expect(Facter::Core::Execution).to receive(:execute)
-            .with("dpkg-query --showformat='${Version}' --show puppetdb")
-            .and_return('7.9.0-1ubuntu1')
-
-          expect(Facter.fact(:puppetdb_version).value).to eq('7.9.0')
-        end
-
-        it 'returns nil if the command execution fails' do
-          allow(Facter::Core::Execution).to receive(:execute).with("dpkg-query --showformat='${Version}' --show puppetdb").and_raise(Facter::Core::Execution::ExecutionFailure)
-
-          expect(Facter.fact(:puppetdb_version).value).to be_nil
-        end
-      end
-    end
-
-    context 'on a non-Debian-based system' do
-      before do
-        allow(Facter).to receive(:value).with(:os).and_return({ 'family' => 'RedHat' })
-      end
-
+    context 'on a default system' do
       it 'returns the correct version from puppetdb --version' do
         expect(Facter::Core::Execution).to receive(:execute)
           .with('puppetdb --version')
@@ -82,7 +28,7 @@ describe 'puppetdb_version' do
   end
 
   context 'when puppetdb is not available' do
-    before do
+    before(:each) do
       allow(Facter::Util::Resolution).to receive(:which).with('puppetdb').and_return(nil)
     end
 


### PR DESCRIPTION
i tried to get around the debian package differences and report a version also if this package is used. sadly somehow i didnt get `puppetdb version` running on my ubuntu testbox. so i tried to get the version from the package itself if it is not the puppetlabs one.

fixes: #413