### PR TITLE
fix: Use C.UTF8 locale to create puppetdb database instead of en_US

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -150,7 +150,7 @@ class puppetdb::database::postgresql (
       user     => $database_username,
       password => $database_password,
       encoding => 'UTF8',
-      locale   => 'en_US.UTF-8',
+      locale   => 'C.UTF-8',
       grant    => 'all',
       port     => $port,
     }

--- a/spec/unit/classes/database/postgresql_spec.rb
+++ b/spec/unit/classes/database/postgresql_spec.rb
@@ -63,7 +63,7 @@ describe 'puppetdb::database::postgresql', type: :class do
             grant:    'all',
             port:     params[:database_port].to_i,
             encoding: 'UTF8',
-            locale:   'en_US.UTF-8',
+            locale:   'C.UTF-8',
           )
       }
 


### PR DESCRIPTION
This should fix the [breaking change](https://github.com/puppetlabs/puppetlabs-puppetdb/commit/0c5c2708f4683a6056ab8bb9e9cae092f09786d1#commitcomment-143826184) introduced by https://github.com/puppetlabs/puppetlabs-puppetdb/commit/0c5c2708f4683a6056ab8bb9e9cae092f09786d1 were the puppetdb can't be created on a system where the locale en_US.UTF-8 is not installed.


This has been also reported in in https://github.com/puppetlabs/puppetlabs-puppetdb/issues/412#issuecomment-2207551604

C.UTF-8 seems a better choice in this case, I'm not a locales expert enough to say if it's the perfect choice.
