### PR TITLE
feat: use variable for postgresql locale

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -49,6 +49,8 @@
 #
 # @param postgresql_ssl_ca_cert_path
 #   Path to the Postgresql SSL CA.
+# @param postgresql_locale
+#   The locale to use for the database. Defaults to `C.UTF-8`.
 #
 # @param read_database_username
 #   The name of the read database user to connect as. Defaults to `puppetdb-read`. This
@@ -85,6 +87,7 @@ class puppetdb::database::postgresql (
   $postgresql_ssl_key_path     = $puppetdb::params::postgresql_ssl_key_path,
   $postgresql_ssl_cert_path    = $puppetdb::params::postgresql_ssl_cert_path,
   $postgresql_ssl_ca_cert_path = $puppetdb::params::postgresql_ssl_ca_cert_path,
+  $postgresql_locale           = $puppetdb::params::postgresql_locale,
   $read_database_username      = $puppetdb::params::read_database_username,
   Variant[String[1], Sensitive[String[1]]] $read_database_password = $puppetdb::params::read_database_password,
   $read_database_host          = $puppetdb::params::read_database_host,
@@ -150,7 +153,7 @@ class puppetdb::database::postgresql (
       user     => $database_username,
       password => $database_password,
       encoding => 'UTF8',
-      locale   => 'en_US.UTF-8',
+      locale   => $postgresql_locale,
       grant    => 'all',
       port     => $port,
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -196,6 +196,9 @@ class puppetdb::params inherits puppetdb::globals {
   $postgresql_ssl_key_path      = "${postgresql_ssl_folder}/private_keys/${trusted['certname']}.pem"
   $postgresql_ssl_ca_cert_path  = "${postgresql_ssl_folder}/certs/ca.pem"
 
+  # Configuration of the locales
+  $postgresql_locale = 'C.UTF-8'
+
   # certificates used for Jetty configuration
   $ssl_set_cert_paths       = false
   $ssl_cert_path            = "${ssl_dir}/public.pem"

--- a/spec/unit/classes/database/postgresql_spec.rb
+++ b/spec/unit/classes/database/postgresql_spec.rb
@@ -63,7 +63,7 @@ describe 'puppetdb::database::postgresql', type: :class do
             grant:    'all',
             port:     params[:database_port].to_i,
             encoding: 'UTF8',
-            locale:   'en_US.UTF-8',
+            locale:   params[:postgresql_locale],
           )
       }
 


### PR DESCRIPTION
This should fix the [breaking change](https://github.com/puppetlabs/puppetlabs-puppetdb/commit/0c5c2708f4683a6056ab8bb9e9cae092f09786d1#commitcomment-143826184) introduced by https://github.com/puppetlabs/puppetlabs-puppetdb/commit/0c5c2708f4683a6056ab8bb9e9cae092f09786d1 were the puppetdb can't be created on a system where the locale EN_us.UTF-8 is not installed.

This has been also reported in in https://github.com/puppetlabs/puppetlabs-puppetdb/issues/412#issuecomment-2207551604

C.UTF-8 seems a better choice in this case, I'm not a locales expert enough to say if it's the perfect choice.