### PR TITLE
Issue 430: Fix Datatype for listen_addresses

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -71,7 +71,7 @@
 #   PostgreSQL password authentication method, either `md5` or `scram-sha-256`
 #
 class puppetdb::database::postgresql (
-  Stdlib::Host                                       $listen_addresses            = $puppetdb::params::database_host,
+  Variant[Stdlib::Host, Pattern[/^\*$/]]             $listen_addresses            = $puppetdb::params::database_host,
   Stdlib::Host                                       $puppetdb_server             = $puppetdb::params::puppetdb_server,
   String[1]                                          $database_name               = $puppetdb::params::database_name,
   String[1]                                          $database_username           = $puppetdb::params::database_username,


### PR DESCRIPTION
Additionally allow Asterisk `*` for `listen_addresses`, as stated in Variabledocumentation.

fixes 5e672902b646bcead0be494d42f88a6afa332e6b