### PR TITLE
Update storeconfig ini section with masters

### DIFF
--- a/manifests/master/storeconfigs.pp
+++ b/manifests/master/storeconfigs.pp
@@ -9,7 +9,7 @@ class puppetdb::master::storeconfigs (
   if $masterless {
     $puppet_conf_section = 'main'
   } else {
-    $puppet_conf_section = 'master'
+    $puppet_conf_section = 'server'
   }
 
   $storeconfigs_ensure = $enable ? {


### PR DESCRIPTION
fixes #425

I can no longer tell what version of Puppet-Core changes this. But Puppetserver version 6.x already had no "master" section in `puppet.conf` anymore. This PR should finally fix the puppetdb module in that regard.