### PR TITLE
Fix deprecated facts blacklist setting

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -96,7 +96,7 @@ The following parameters are available in the `puppetdb` class:
 * [`node_ttl`](#-puppetdb--node_ttl)
 * [`node_purge_ttl`](#-puppetdb--node_purge_ttl)
 * [`report_ttl`](#-puppetdb--report_ttl)
-* [`facts_blacklist`](#-puppetdb--facts_blacklist)
+* [`facts_blocklist`](#-puppetdb--facts_blocklist)
 * [`gc_interval`](#-puppetdb--gc_interval)
 * [`node_purge_gc_batch_limit`](#-puppetdb--node_purge_gc_batch_limit)
 * [`conn_max_age`](#-puppetdb--conn_max_age)
@@ -428,13 +428,13 @@ The length of time reports should be stored before being deleted. (defaults to
 
 Default value: `$puppetdb::params::report_ttl`
 
-##### <a name="-puppetdb--facts_blacklist"></a>`facts_blacklist`
+##### <a name="-puppetdb--facts_blocklist"></a>`facts_blocklist`
 
 Data type: `Optional[Array]`
 
 A list of fact names to be ignored whenever submitted.
 
-Default value: `$puppetdb::params::facts_blacklist`
+Default value: `$puppetdb::params::facts_blocklist`
 
 ##### <a name="-puppetdb--gc_interval"></a>`gc_interval`
 
@@ -1395,7 +1395,7 @@ The following parameters are available in the `puppetdb::server` class:
 * [`node_ttl`](#-puppetdb--server--node_ttl)
 * [`node_purge_ttl`](#-puppetdb--server--node_purge_ttl)
 * [`report_ttl`](#-puppetdb--server--report_ttl)
-* [`facts_blacklist`](#-puppetdb--server--facts_blacklist)
+* [`facts_blocklist`](#-puppetdb--server--facts_blocklist)
 * [`gc_interval`](#-puppetdb--server--gc_interval)
 * [`node_purge_gc_batch_limit`](#-puppetdb--server--node_purge_gc_batch_limit)
 * [`conn_max_age`](#-puppetdb--server--conn_max_age)
@@ -1656,13 +1656,13 @@ The length of time reports should be stored before being deleted. (defaults to
 
 Default value: `$puppetdb::params::report_ttl`
 
-##### <a name="-puppetdb--server--facts_blacklist"></a>`facts_blacklist`
+##### <a name="-puppetdb--server--facts_blocklist"></a>`facts_blocklist`
 
 Data type: `Optional[Array]`
 
 A list of fact names to be ignored whenever submitted.
 
-Default value: `$puppetdb::params::facts_blacklist`
+Default value: `$puppetdb::params::facts_blocklist`
 
 ##### <a name="-puppetdb--server--gc_interval"></a>`gc_interval`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -97,6 +97,7 @@ The following parameters are available in the `puppetdb` class:
 * [`node_purge_ttl`](#-puppetdb--node_purge_ttl)
 * [`report_ttl`](#-puppetdb--report_ttl)
 * [`facts_blocklist`](#-puppetdb--facts_blocklist)
+* [`facts_blocklist_type`](#-puppetdb--facts_blocklist_type)
 * [`gc_interval`](#-puppetdb--gc_interval)
 * [`node_purge_gc_batch_limit`](#-puppetdb--node_purge_gc_batch_limit)
 * [`conn_max_age`](#-puppetdb--conn_max_age)
@@ -435,6 +436,15 @@ Data type: `Optional[Array]`
 A list of fact names to be ignored whenever submitted.
 
 Default value: `$puppetdb::params::facts_blocklist`
+
+##### <a name="-puppetdb--facts_blocklist_type"></a>`facts_blocklist_type`
+
+Data type: `Optional[Enum['literal', 'regex']]`
+
+Select mode for interpreting the fact-blocklist, either literally or as
+Java regular expressions.
+
+Default value: `$puppetdb::params::facts_blocklist_type`
 
 ##### <a name="-puppetdb--gc_interval"></a>`gc_interval`
 
@@ -1396,6 +1406,7 @@ The following parameters are available in the `puppetdb::server` class:
 * [`node_purge_ttl`](#-puppetdb--server--node_purge_ttl)
 * [`report_ttl`](#-puppetdb--server--report_ttl)
 * [`facts_blocklist`](#-puppetdb--server--facts_blocklist)
+* [`facts_blocklist_type`](#-puppetdb--server--facts_blocklist_type)
 * [`gc_interval`](#-puppetdb--server--gc_interval)
 * [`node_purge_gc_batch_limit`](#-puppetdb--server--node_purge_gc_batch_limit)
 * [`conn_max_age`](#-puppetdb--server--conn_max_age)
@@ -1663,6 +1674,15 @@ Data type: `Optional[Array]`
 A list of fact names to be ignored whenever submitted.
 
 Default value: `$puppetdb::params::facts_blocklist`
+
+##### <a name="-puppetdb--facts_blocklist_type"></a>`facts_blocklist_type`
+
+Data type: `Optional[Enum['literal', 'regex']]`
+
+Select mode for interpreting the fact-blocklist, either literally or as
+Java regular expressions.
+
+Default value: `$puppetdb::params::facts_blocklist_type`
 
 ##### <a name="-puppetdb--server--gc_interval"></a>`gc_interval`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -120,7 +120,7 @@
 #   The length of time reports should be stored before being deleted. (defaults to
 #   `14d`, which is a 14-day period). This option is supported in PuppetDB >= 1.1.0.
 #
-# @param facts_blacklist
+# @param facts_blocklist
 #   A list of fact names to be ignored whenever submitted.
 #
 # @param gc_interval
@@ -388,7 +388,7 @@ class puppetdb (
   Pattern[/\A[0-9dhms]+\Z/]                                            $node_ttl                          = $puppetdb::params::node_ttl,
   Pattern[/\A[0-9dhms]+\Z/]                                            $node_purge_ttl                    = $puppetdb::params::node_purge_ttl,
   Pattern[/\A[0-9dhms]+\Z/]                                            $report_ttl                        = $puppetdb::params::report_ttl,
-  Optional[Array]                                                      $facts_blacklist                   = $puppetdb::params::facts_blacklist,
+  Optional[Array]                                                      $facts_blocklist                   = $puppetdb::params::facts_blocklist,
   Variant[Integer[0], Pattern[/\A[0-9]+\Z/]]                           $gc_interval                       = $puppetdb::params::gc_interval,
   Variant[Integer[0], Pattern[/\A[0-9]+\Z/]]                           $node_purge_gc_batch_limit         = $puppetdb::params::node_purge_gc_batch_limit,
   Variant[Integer[0], Pattern[/\A[0-9]+\Z/]]                           $conn_max_age                      = $puppetdb::params::conn_max_age,
@@ -464,7 +464,7 @@ class puppetdb (
     node_ttl                          => $node_ttl,
     node_purge_ttl                    => $node_purge_ttl,
     report_ttl                        => $report_ttl,
-    facts_blacklist                   => $facts_blacklist,
+    facts_blocklist                   => $facts_blocklist,
     gc_interval                       => $gc_interval,
     node_purge_gc_batch_limit         => $node_purge_gc_batch_limit,
     conn_max_age                      => $conn_max_age,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,6 +123,10 @@
 # @param facts_blocklist
 #   A list of fact names to be ignored whenever submitted.
 #
+# @param facts_blocklist_type
+#   Control how to interpret the facts-blocklist setting, either literally,
+#   or as Java regular expressions.
+#
 # @param gc_interval
 #   This controls how often (in minutes) to compact the database. The compaction
 #   process reclaims space and deletes unnecessary rows. If not supplied, the
@@ -389,6 +393,7 @@ class puppetdb (
   Pattern[/\A[0-9dhms]+\Z/]                                            $node_purge_ttl                    = $puppetdb::params::node_purge_ttl,
   Pattern[/\A[0-9dhms]+\Z/]                                            $report_ttl                        = $puppetdb::params::report_ttl,
   Optional[Array]                                                      $facts_blocklist                   = $puppetdb::params::facts_blocklist,
+  Optional[Enum['literal', 'regex']]                                   $facts_blocklist_type              = $puppetdb::params::facts_blocklist_type,
   Variant[Integer[0], Pattern[/\A[0-9]+\Z/]]                           $gc_interval                       = $puppetdb::params::gc_interval,
   Variant[Integer[0], Pattern[/\A[0-9]+\Z/]]                           $node_purge_gc_batch_limit         = $puppetdb::params::node_purge_gc_batch_limit,
   Variant[Integer[0], Pattern[/\A[0-9]+\Z/]]                           $conn_max_age                      = $puppetdb::params::conn_max_age,
@@ -465,6 +470,7 @@ class puppetdb (
     node_purge_ttl                    => $node_purge_ttl,
     report_ttl                        => $report_ttl,
     facts_blocklist                   => $facts_blocklist,
+    facts_blocklist_type              => $facts_blocklist_type,
     gc_interval                       => $gc_interval,
     node_purge_gc_batch_limit         => $node_purge_gc_batch_limit,
     conn_max_age                      => $conn_max_age,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,7 +49,7 @@ class puppetdb::params inherits puppetdb::globals {
   $node_purge_ttl         = '14d'
   $report_ttl             = '14d'
 
-  $facts_blacklist        = undef
+  $facts_blocklist        = undef
 
   $gc_interval               = '60'
   $node_purge_gc_batch_limit = '25'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,6 +50,7 @@ class puppetdb::params inherits puppetdb::globals {
   $report_ttl             = '14d'
 
   $facts_blocklist        = undef
+  $facts_blocklist_type   = undef
 
   $gc_interval               = '60'
   $node_purge_gc_batch_limit = '25'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -94,6 +94,10 @@
 # @param facts_blocklist
 #   A list of fact names to be ignored whenever submitted.
 #
+# @param facts_blocklist_type
+#   Control how to interpret the facts-blocklist setting, either literally,
+#   or as Java regular expressions.
+#
 # @param gc_interval
 #   This controls how often (in minutes) to compact the database. The compaction
 #   process reclaims space and deletes unnecessary rows. If not supplied, the
@@ -473,6 +477,7 @@ class puppetdb::server (
     node_purge_ttl            => $node_purge_ttl,
     report_ttl                => $report_ttl,
     facts_blocklist           => $facts_blocklist,
+    facts_blocklist_type      => $facts_blocklist_type,
     gc_interval               => $gc_interval,
     node_purge_gc_batch_limit => $node_purge_gc_batch_limit,
     conn_max_age              => $conn_max_age,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -91,7 +91,7 @@
 #   The length of time reports should be stored before being deleted. (defaults to
 #   `14d`, which is a 14-day period). This option is supported in PuppetDB >= 1.1.0.
 #
-# @param facts_blacklist
+# @param facts_blocklist
 #   A list of fact names to be ignored whenever submitted.
 #
 # @param gc_interval
@@ -344,7 +344,7 @@ class puppetdb::server (
   Pattern[/\A[0-9dhms]+\Z/]                                            $node_ttl                          = $puppetdb::params::node_ttl,
   Pattern[/\A[0-9dhms]+\Z/]                                            $node_purge_ttl                    = $puppetdb::params::node_purge_ttl,
   Pattern[/\A[0-9dhms]+\Z/]                                            $report_ttl                        = $puppetdb::params::report_ttl,
-  Optional[Array]                                                      $facts_blacklist                   = $puppetdb::params::facts_blacklist,
+  Optional[Array]                                                      $facts_blocklist                   = $puppetdb::params::facts_blocklist,
   Variant[Integer[0], Pattern[/\A[0-9]+\Z/]]                           $gc_interval                       = $puppetdb::params::gc_interval,
   Variant[Integer[0], Pattern[/\A[0-9]+\Z/]]                           $node_purge_gc_batch_limit         = $puppetdb::params::node_purge_gc_batch_limit,
   Variant[Integer[0], Pattern[/\A[0-9]+\Z/]]                           $conn_max_age                      = $puppetdb::params::conn_max_age,
@@ -472,7 +472,7 @@ class puppetdb::server (
     node_ttl                  => $node_ttl,
     node_purge_ttl            => $node_purge_ttl,
     report_ttl                => $report_ttl,
-    facts_blacklist           => $facts_blacklist,
+    facts_blocklist           => $facts_blocklist,
     gc_interval               => $gc_interval,
     node_purge_gc_batch_limit => $node_purge_gc_batch_limit,
     conn_max_age              => $conn_max_age,

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -14,6 +14,7 @@ class puppetdb::server::database (
   Pattern[/\A[0-9dhms]+\Z/]                                            $node_purge_ttl            = $puppetdb::params::node_purge_ttl,
   Pattern[/\A[0-9dhms]+\Z/]                                            $report_ttl                = $puppetdb::params::report_ttl,
   Optional[Array]                                                      $facts_blocklist           = $puppetdb::params::facts_blocklist,
+  Optional[Enum['literal', 'regex']]                                   $facts_blocklist_type      = $puppetdb::params::facts_blocklist_type,
   Variant[Integer[0], Pattern[/\A[0-9]+\Z/]]                           $gc_interval               = $puppetdb::params::gc_interval,
   Variant[Integer[0], Pattern[/\A[0-9]+\Z/]]                           $node_purge_gc_batch_limit = $puppetdb::params::node_purge_gc_batch_limit,
   Variant[Integer[0], Pattern[/\A[0-9]+\Z/]]                           $conn_max_age              = $puppetdb::params::conn_max_age,
@@ -178,6 +179,13 @@ class puppetdb::server::database (
     ini_setting { 'puppetdb_facts_blocklist':
       ensure  => absent,
       setting => 'facts-blocklist',
+    }
+  }
+
+  if $facts_blocklist_type {
+    ini_setting { 'puppetdb_facts_blocklist_type':
+      setting => 'facts-blocklist-type',
+      value   => $joined_facts_blocklist,
     }
   }
 }

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -13,7 +13,7 @@ class puppetdb::server::database (
   Pattern[/\A[0-9dhms]+\Z/]                                            $node_ttl                  = $puppetdb::params::node_ttl,
   Pattern[/\A[0-9dhms]+\Z/]                                            $node_purge_ttl            = $puppetdb::params::node_purge_ttl,
   Pattern[/\A[0-9dhms]+\Z/]                                            $report_ttl                = $puppetdb::params::report_ttl,
-  Optional[Array]                                                      $facts_blacklist           = $puppetdb::params::facts_blacklist,
+  Optional[Array]                                                      $facts_blocklist           = $puppetdb::params::facts_blocklist,
   Variant[Integer[0], Pattern[/\A[0-9]+\Z/]]                           $gc_interval               = $puppetdb::params::gc_interval,
   Variant[Integer[0], Pattern[/\A[0-9]+\Z/]]                           $node_purge_gc_batch_limit = $puppetdb::params::node_purge_gc_batch_limit,
   Variant[Integer[0], Pattern[/\A[0-9]+\Z/]]                           $conn_max_age              = $puppetdb::params::conn_max_age,
@@ -168,16 +168,16 @@ class puppetdb::server::database (
     }
   }
 
-  if ($facts_blacklist) and length($facts_blacklist) != 0 {
-    $joined_facts_blacklist = join($facts_blacklist, ', ')
-    ini_setting { 'puppetdb_facts_blacklist':
-      setting => 'facts-blacklist',
-      value   => $joined_facts_blacklist,
+  if ($facts_blocklist) and length($facts_blocklist) != 0 {
+    $joined_facts_blocklist = join($facts_blocklist, ', ')
+    ini_setting { 'puppetdb_facts_blocklist':
+      setting => 'facts-blocklist',
+      value   => $joined_facts_blocklist,
     }
   } else {
-    ini_setting { 'puppetdb_facts_blacklist':
+    ini_setting { 'puppetdb_facts_blocklist':
       ensure  => absent,
-      setting => 'facts-blacklist',
+      setting => 'facts-blocklist',
     }
   }
 }

--- a/spec/unit/classes/server/database_ini_spec.rb
+++ b/spec/unit/classes/server/database_ini_spec.rb
@@ -156,6 +156,15 @@ describe 'puppetdb::server::database', type: :class do
             'setting' => 'facts-blocklist',
           )
       }
+      it {
+        is_expected.to contain_ini_setting('puppetdb_facts_blocklist')
+          .with(
+            'ensure'  => 'absent',
+            'path'    => "#{pdbconfdir}/database.ini",
+            'section' => 'database',
+            'setting' => 'facts-blocklist-type',
+          )
+      }
     end
   end
 
@@ -177,6 +186,40 @@ describe 'puppetdb::server::database', type: :class do
           'section' => 'database',
           'setting' => 'facts-blocklist',
           'value'   => 'one_fact, another_fact',
+        )
+    }
+  end
+
+  describe 'when using "literal" facts_blocklist_type' do
+    let(:params) do
+      {'facts_blocklist_type' => 'literal'}
+    end
+
+    it {
+      is_expected.to contain_ini_setting('puppetdb_facts_blocklist')
+        .with(
+          'ensure'  => 'present',
+          'path'    => '/etc/puppetlabs/puppetdb/conf.d/database.ini',
+          'section' => 'database',
+          'setting' => 'facts-blocklist-type',
+          'value'   => 'literal',
+        )
+    }
+  end
+
+  describe 'when using "regex" facts_blocklist_type' do
+    let(:params) do
+      {'facts_blocklist_type' => 'regex'}
+    end
+
+    it {
+      is_expected.to contain_ini_setting('puppetdb_facts_blocklist')
+        .with(
+          'ensure'  => 'present',
+          'path'    => '/etc/puppetlabs/puppetdb/conf.d/database.ini',
+          'section' => 'database',
+          'setting' => 'facts-blocklist-type',
+          'value'   => 'regex',
         )
     }
   end

--- a/spec/unit/classes/server/database_ini_spec.rb
+++ b/spec/unit/classes/server/database_ini_spec.rb
@@ -148,21 +148,21 @@ describe 'puppetdb::server::database', type: :class do
       }
       it { is_expected.not_to contain_ini_setting('puppetdb_database_max_pool_size') }
       it {
-        is_expected.to contain_ini_setting('puppetdb_facts_blacklist')
+        is_expected.to contain_ini_setting('puppetdb_facts_blocklist')
           .with(
             'ensure'  => 'absent',
             'path'    => "#{pdbconfdir}/database.ini",
             'section' => 'database',
-            'setting' => 'facts-blacklist',
+            'setting' => 'facts-blocklist',
           )
       }
     end
   end
 
-  describe 'when using facts_blacklist' do
+  describe 'when using facts_blocklist' do
     let(:params) do
       {
-        'facts_blacklist' => [
+        'facts_blocklist' => [
           'one_fact',
           'another_fact',
         ],
@@ -170,12 +170,12 @@ describe 'puppetdb::server::database', type: :class do
     end
 
     it {
-      is_expected.to contain_ini_setting('puppetdb_facts_blacklist')
+      is_expected.to contain_ini_setting('puppetdb_facts_blocklist')
         .with(
           'ensure'  => 'present',
           'path'    => '/etc/puppetlabs/puppetdb/conf.d/database.ini',
           'section' => 'database',
-          'setting' => 'facts-blacklist',
+          'setting' => 'facts-blocklist',
           'value'   => 'one_fact, another_fact',
         )
     }


### PR DESCRIPTION
fixes #427 

Additionally to renaming the deprecated facts-blacklist setting to facts-blocklist, a new, closely related setting is supported called [facts-blacklist-type](https://help.puppet.com/pdb/current/topics/configure.htm#facts-blocklist-type).