### PR TITLE
Updating code owner from puppetdb to professional-services

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @puppetlabs/puppetdb @bastelfreak @smortex
+* @puppetlabs/professional-services @bastelfreak @smortex


### PR DESCRIPTION
This is an unsupported module that no longer has an assigned engineering team. Professional Services team will now have access to review/merge.